### PR TITLE
CcxEnableSmee, CcxSetCacWeights ,CcxInitializeCp, DfFindDeviceTypeEntryInMap and DfGetRootBridgeInfo unit tests. 

### DIFF
--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dsc.inc
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dsc.inc
@@ -23,6 +23,8 @@
   UtxSIMMockLib|$(OPENSIL_UTPATH)/Mocks/UtxSIMMockLib/UtxSIMMockLib.inf
   UtSilServicesMockLib|$(OPENSIL_UTPATH)/Mocks/UtSilServicesMockLib/UtSilServicesMockLib.inf
   UtSmnAccessStubLib|$(OPENSIL_UTPATH)/Stubs/UtSmnAccessStubLib/UtSmnAccessStubLib.inf
+  UtMsrRegStubLib|$(OPENSIL_UTPATH)/Stubs/UtMsrRegStubLib/UtMsrRegStubLib.inf
+  UtxUslCcxRolesMockLib|$(OPENSIL_UTPATH)/Mocks/UtxUslCcxRolesMockLib/UtxUslCcxRolesMockLib.inf
 
 [BuildOptions]
   GCC:*_*_*_CC_FLAGS     = -D UNIT_TEST_RUN

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkgGn.dsc.inc
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkgGn.dsc.inc
@@ -20,3 +20,4 @@
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Fch/FchAb/FchInitResetAbUt/FchInitResetAbUt.inf
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Fch/FchAb/FchAbSetInputBlkUt/FchAbSetInputBlkUt.inf
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Fch/FchAb/FchInitEnvAbUt/FchInitEnvAbUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxEnableSmee/CcxEnableSmeeUt.inf

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkgGn.dsc.inc
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkgGn.dsc.inc
@@ -21,3 +21,4 @@
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Fch/FchAb/FchAbSetInputBlkUt/FchAbSetInputBlkUt.inf
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Fch/FchAb/FchInitEnvAbUt/FchInitEnvAbUt.inf
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxEnableSmee/CcxEnableSmeeUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSetCacWeights/CcxSetCacWeightsUt.inf

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkgGn.dsc.inc
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkgGn.dsc.inc
@@ -24,3 +24,4 @@
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSetCacWeights/CcxSetCacWeightsUt.inf
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSyncMiscMsrs/CcxSyncMiscMsrsUt.inf
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSetMiscMsrs/CcxSetMiscMsrsUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/TypeEntryInMap/TypeEntryInMapUt.inf

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkgGn.dsc.inc
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkgGn.dsc.inc
@@ -34,3 +34,8 @@
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetDieSystemOffset/GetDieSystemOffsetUt.inf
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetDeviceMapOnDie/GetDeviceMapOnDieUt.inf
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetHostBridgeBB/GetHostBridgeBBUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetHostBridgeBL/GetHostBridgeBLUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetPhysRootBN/GetPhysRootBNUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/FindComponentLM/FindComponentLMUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/FbrRegstrAccRead/FbrRegstrAccReadUt.inf  
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/FbrRegstrAccWrite/FbrRegstrAccWriteUt.inf  

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkgGn.dsc.inc
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkgGn.dsc.inc
@@ -26,3 +26,11 @@
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSetMiscMsrs/CcxSetMiscMsrsUt.inf
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/TypeEntryInMap/TypeEntryInMapUt.inf
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/RootBridgeInfo/RootBridgeInfoUt.inf  
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfProcessors/NumberOfProcessorsUt.inf  
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfSystemDies/NumberOfSystemDiesUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfSystemRB/NumberOfSystemRBUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfRBOnS/NumberOfRBOnSUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfRBOnD/NumberOfRBOnDUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetDieSystemOffset/GetDieSystemOffsetUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetDeviceMapOnDie/GetDeviceMapOnDieUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetHostBridgeBB/GetHostBridgeBBUt.inf

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkgGn.dsc.inc
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkgGn.dsc.inc
@@ -25,3 +25,4 @@
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSyncMiscMsrs/CcxSyncMiscMsrsUt.inf
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSetMiscMsrs/CcxSetMiscMsrsUt.inf
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/TypeEntryInMap/TypeEntryInMapUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/RootBridgeInfo/RootBridgeInfoUt.inf  

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkgGn.dsc.inc
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkgGn.dsc.inc
@@ -22,3 +22,5 @@
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Fch/FchAb/FchInitEnvAbUt/FchInitEnvAbUt.inf
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxEnableSmee/CcxEnableSmeeUt.inf
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSetCacWeights/CcxSetCacWeightsUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSyncMiscMsrs/CcxSyncMiscMsrsUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSetMiscMsrs/CcxSetMiscMsrsUt.inf

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Include/Library/UtMsrRegStubLib.h
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Include/Library/UtMsrRegStubLib.h
@@ -1,0 +1,36 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file UtMsrRegStubLib.h
+ * @brief This header contains definitions used by UtMsrRegStubLib
+ *
+ */
+
+ #pragma once
+
+void xUslWrMsr(
+    uint32_t msrAddress, 
+    uint64_t msrValue
+    );
+
+uint64_t xUslRdMsr (
+    uint32_t MsrAddress
+    );
+
+void xUslMsrAndThenOr (
+    uint32_t Index, 
+    uint64_t AndData, 
+    uint64_t OrData
+    );
+
+void xUslMsrOr (
+    uint32_t Index, 
+    uint64_t OrData
+    );
+
+void xUslMsrAnd (
+    uint32_t Index, 
+    uint64_t AndData
+    );
+
+

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Include/Library/UtSilServicesMockLib.h
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Include/Library/UtSilServicesMockLib.h
@@ -13,6 +13,13 @@ MockSilGetCommon2RevXferTableOnce (
   SIL_STATUS      ExpectedSilStatus
   );
 
+void 
+MockSilGetCommon2RevXferTableManyTimes(
+  void *ExpectedXferTable,
+  SIL_STATUS ExpectedSilStatus,
+  uint32_t Count
+);
+
 void
 MockSilInitCommon2RevXferTableOnce (
   void            *ExpectedXferTable,

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Include/Library/UtxUslCcxRolesMockLib.h
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Include/Library/UtxUslCcxRolesMockLib.h
@@ -1,0 +1,18 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file UtxUslCcxRolesMockLib.h
+ * @brief This header contains definitions used by UtxUslCcxRolesMockLib
+ *
+ */
+#pragma once
+
+void
+MockxUslIsComputeUnitPrimary (
+    bool ExpectedComputeStatus
+    );
+
+bool
+xUslIsComputeUnitPrimary (
+    void
+    );

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Library/Mocks/UtSilServicesMockLib/UtSilServicesMockLib.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Library/Mocks/UtSilServicesMockLib/UtSilServicesMockLib.c
@@ -282,6 +282,37 @@ SilGetCommon2RevXferTable (
 }
 
 /**
+ * MockSilGetCommon2RevXferTableManyTimes
+ *
+ * @brief Arm expected return values for a Count number of calls to SilGetCommon2RevXferTable
+ *
+ * @param ExpectedXferTable  The expected return value from SilGetCommon2RevXferTable.
+ *
+ *                        - In a passing case, this parameter should be a pointer to a buffer for the transfer table.
+ *                        - In a failing case, this parameter should be NULL.
+ *
+ * @param ExpectedSilStatus  The expected return Status from SilGetCommon2RevXferTable.
+ *
+ *                        - In a passing case, this parameter should SilPass.
+ *                        - In a failing case, this parameter should an error Status.
+ *
+ * @param Count             Number of times to mock XferTable
+ */
+void 
+MockSilGetCommon2RevXferTableManyTimes(
+  void *ExpectedXferTable,
+  SIL_STATUS ExpectedSilStatus,
+  uint32_t Count
+)
+{
+    for(uint32_t i = 0; i < Count; ++i)
+    {
+        expect_in_range(SilGetCommon2RevXferTable, IpId, (uint32_t)SilId_SocCommon, ((uint32_t)SilId_ListEnd - 1));
+        will_return(SilGetCommon2RevXferTable, ExpectedXferTable);
+        will_return(SilGetCommon2RevXferTable, ExpectedSilStatus);
+    }
+}
+/**
  * MockSilGetCommon2RevXferTableOnce
  *
  * @brief Arm expected return value for a single call to SilGetCommon2RevXferTable
@@ -296,14 +327,11 @@ SilGetCommon2RevXferTable (
  *                        - In a passing case, this parameter should SilPass.
  *                        - In a failing case, this parameter should an error Status.
  */
-void
-MockSilGetCommon2RevXferTableOnce (
-  void            *ExpectedXferTable,
-  SIL_STATUS      ExpectedSilStatus
-  )
+void 
+MockSilGetCommon2RevXferTableOnce(
+  void *ExpectedXferTable,
+  SIL_STATUS ExpectedSilStatus
+)
 {
-  // Verify IpId is within the range defined by SIL_DATA_BLOCK_ID
-  expect_in_range (SilGetCommon2RevXferTable, IpId, (uint32_t)SilId_SocCommon, ((uint32_t)SilId_ListEnd - 1));
-  will_return (SilGetCommon2RevXferTable, ExpectedXferTable);
-  will_return (SilGetCommon2RevXferTable, ExpectedSilStatus);
+  MockSilGetCommon2RevXferTableManyTimes(ExpectedXferTable, ExpectedSilStatus, 1);
 }

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Library/Mocks/UtxUslCcxRolesMockLib/UtxUslCcxRolesMockLib.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Library/Mocks/UtxUslCcxRolesMockLib/UtxUslCcxRolesMockLib.c
@@ -1,0 +1,38 @@
+/* Copyright (C) 2022 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file UtxUslCcxRolesMockLib.c
+ * @brief Defines cpu helper function definition.
+ *
+ */
+
+#include <SilCommon.h> 
+
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+bool
+xUslIsComputeUnitPrimary (
+    void
+    )
+{
+     return mock_type(bool);
+}
+
+/**
+ * MockxUslIsComputeUnitPrimary
+ *
+ * @brief xUslIsComputeUnitPrimary should return false or true value 
+ *
+ * @param boll Expected Compute Unit Primary Status  
+ */
+void
+MockxUslIsComputeUnitPrimary (
+    bool ExpectedComputeStatus 
+    )
+{
+  will_return(xUslIsComputeUnitPrimary, ExpectedComputeStatus);
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Library/Mocks/UtxUslCcxRolesMockLib/UtxUslCcxRolesMockLib.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Library/Mocks/UtxUslCcxRolesMockLib/UtxUslCcxRolesMockLib.inf
@@ -1,0 +1,23 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  UtxUslCcxRolesMockLib.inf
+# @brief
+#
+
+[Defines]
+  INF_VERSION                    = 0x00010006
+  BASE_NAME                      = UtxUslCcxRolesMockLib
+  FILE_GUID                      = 885C8C77-DDB6-4481-A6C4-F0584B58AF14
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = UtxUslCcxRolesMockLib
+
+[Sources]
+  UtxUslCcxRolesMockLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Library/Stubs/UtMsrRegStubLib/UtMsrRegStubLib.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Library/Stubs/UtMsrRegStubLib/UtMsrRegStubLib.c
@@ -1,0 +1,50 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file  UtMsrRegStubLib.c
+ * @brief Define Msr registers
+ *
+ */
+
+#include <SilCommon.h> 
+#include <MsrReg.h> 
+
+void xUslWrMsr(
+    uint32_t msrAddress, 
+    uint64_t msrValue
+    ) 
+{
+    return; 
+}
+
+uint64_t xUslRdMsr (
+    uint32_t MsrAddress
+    )
+{
+    return 0;
+}
+
+void xUslMsrAndThenOr (
+    uint32_t Index, 
+    uint64_t AndData, 
+    uint64_t OrData
+    )
+{
+    return;
+}
+
+void xUslMsrOr (
+    uint32_t Index, 
+    uint64_t OrData
+    )
+{
+    return;
+}
+
+void xUslMsrAnd (
+    uint32_t Index, 
+    uint64_t AndData
+    )
+{
+    return;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Library/Stubs/UtMsrRegStubLib/UtMsrRegStubLib.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Library/Stubs/UtMsrRegStubLib/UtMsrRegStubLib.inf
@@ -1,0 +1,23 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  UtMsrRegStubLib.inf
+# @brief
+#
+
+[Defines]
+  INF_VERSION                    = 0x00010006
+  BASE_NAME                      = UtMsrRegStubLib
+  FILE_GUID                      = A6D783BA-4555-45AB-A72B-6E88DBEDF762
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = UtMsrRegStubLib
+
+[Sources]
+  UtMsrRegStubLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnFiles.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnFiles.json
@@ -5,8 +5,17 @@
   {
     "Component": "FCH",
     "Description": "",
-    "CommonFiles": [
+    "CommonFiles": 
+    [
       {"Name": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\FCH\\Common\\FchCore\\FchAb\\FchAb.c"}
+    ]
+  },
+  {
+    "Component": "CCX",
+    "Description": "",
+    "CommonFiles": 
+    [
+      {"Name": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\CCX\\Common\\CcxMiscInit.c"}
     ]
   }
 ]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnFiles.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnFiles.json
@@ -17,5 +17,13 @@
     [
       {"Name": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\CCX\\Common\\CcxMiscInit.c"}
     ]
+  },
+  {
+    "Component": "DF",
+    "Description": "",
+    "CommonFiles": 
+    [
+      {"Name": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\DF\\Common\\BaseFabricTopologyCmn.c"}
+    ]
   }
 ]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnFiles.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnFiles.json
@@ -25,5 +25,13 @@
     [
       {"Name": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\DF\\Common\\BaseFabricTopologyCmn.c"}
     ]
+  },
+  {
+    "Component": "DfX",
+    "Description": "",
+    "CommonFiles": 
+    [
+      {"Name": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\DF\\DfX\\DfXFabricRegisterAcc.c"}
+    ]
   }
 ]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
@@ -108,6 +108,20 @@
         "Iterations": ["CpbEnableTrue", "CpbEnableFalse"], 
         "Target": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\CCX\\Common\\CcxMiscInit.c", 
         "Timeout": 15
+      },
+      {
+        "Name": "CcxSyncMiscMsrsUt", 
+        "ConfigFile": "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\CCX\\CcxSyncMiscMsrs\\CcxSyncMiscMsrsUt.json", 
+        "Iterations": ["ZeroInitialized_InputStruct"], 
+        "Target": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\CCX\\Common\\CcxMiscInit.c", 
+        "Timeout": 15
+      }, 
+      {
+        "Name": "CcxSetMiscMsrsUt", 
+        "ConfigFile": "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\CCX\\CcxSetMiscMsrs\\CcxSetMiscMsrsUt.json", 
+        "Iterations": ["ZeroInitialized", "ZeroInitialized_EnableSvmAVIC", "SilAborted"], 
+        "Target": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\CCX\\Common\\CcxMiscInit.c", 
+        "Timeout": 15
       }
     ]
   },

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
@@ -94,6 +94,13 @@
         "Iterations" : ["SmeeEnableTrue", "SmeeEnableFalse"],
         "Target"     : "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\CCX\\Common\\CcxMiscInit.c",
         "Timeout"    : 15
+      },
+      {
+        "Name": "CcxSetCacWeightsUt", 
+        "ConfigFile": "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\CCX\\CcxSetCacWeights\\CcxSetCacWeightsUt.json", 
+        "Iterations": ["ComputeTrue_sCacWeightValidSize", "ComputeFalse"], 
+        "Target": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\CCX\\Common\\CcxMiscInit.c", 
+        "Timeout": 15
       }
     ]
   },

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
@@ -128,6 +128,15 @@
   {
     "Component": "DF",
     "Description": "Profile for xUSL DF components",
-    "Tests" : []
+    "Tests" : 
+    [
+      {
+        "Name": "TypeEntryInMapUt", 
+        "ConfigFile": "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\DF\\TypeEntryInMap\\TypeEntryInMapUt.json", 
+        "Iterations": ["TypeMatch", "TypeMismatch"], 
+        "Target": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\DF\\Common\\BaseFabricTopologyCmn.c", 
+        "Timeout": 15
+      }
+    ]
   }
 ]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
@@ -136,6 +136,13 @@
         "Iterations": ["TypeMatch", "TypeMismatch"], 
         "Target": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\DF\\Common\\BaseFabricTopologyCmn.c", 
         "Timeout": 15
+      }, 
+      {
+        "Name": "RootBridgeInfoUt", 
+        "ConfigFile": "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\DF\\RootBridgeInfo\\RootBridgeInfoUt.json", 
+        "Iterations": ["Socket", "Die", "Index", "SystemFabricID", "BusNumberLimit", "PhysicalRootBridgeNumber", "HasFchDevice", "HasSystemMgmtUnit"], 
+        "Target": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\DF\\Common\\BaseFabricTopologyCmn.c", 
+        "Timeout": 15
       }
     ]
   }

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
@@ -143,6 +143,62 @@
         "Iterations": ["Socket", "Die", "Index", "SystemFabricID", "BusNumberLimit", "PhysicalRootBridgeNumber", "HasFchDevice", "HasSystemMgmtUnit"], 
         "Target": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\DF\\Common\\BaseFabricTopologyCmn.c", 
         "Timeout": 15
+      },
+      {
+        "Name": "NumberOfProcessorsUt", 
+        "ConfigFile": "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\DF\\NumberOfProcessors\\NumberOfProcessorsUt.json", 
+        "Iterations": ["Default"], 
+        "Target": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\DF\\DfX\\DfXBaseFabricTopology.c", 
+        "Timeout": 15
+      }, 
+      {
+        "Name": "NumberOfSystemDiesUt", 
+        "ConfigFile": "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\DF\\NumberOfSystemDies\\NumberOfSystemDiesUt.json", 
+        "Iterations": ["Default"], 
+        "Target": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\DF\\DfX\\DfXBaseFabricTopology.c", 
+        "Timeout": 15
+      }, 
+      {
+        "Name": "NumberOfSystemRBUt", 
+        "ConfigFile": "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\DF\\NumberOfSystemRB\\NumberOfSystemRBUt.json", 
+        "Iterations": ["Default"], 
+        "Target": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\DF\\DfX\\DfXBaseFabricTopology.c", 
+        "Timeout": 15
+      }, 
+      {
+        "Name": "NumberOfRBOnSUt", 
+        "ConfigFile": "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\DF\\NumberOfRBOnS\\NumberOfRBOnSUt.json", 
+        "Iterations": ["Default"], 
+        "Target": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\DF\\DfX\\DfXBaseFabricTopology.c", 
+        "Timeout": 15
+      }, 
+      {
+        "Name": "NumberOfRBOnDUt", 
+        "ConfigFile": "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\DF\\NumberOfRBOnD\\NumberOfRBOnDUt.json", 
+        "Iterations": ["Default"], 
+        "Target": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\DF\\DfX\\DfXBaseFabricTopology.c", 
+        "Timeout": 15
+      }, 
+      {
+        "Name": "GetDieSystemOffsetUt", 
+        "ConfigFile": "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\DF\\GetDieSystemOffset\\GetDieSystemOffsetUt.json", 
+        "Iterations": ["Default"], 
+        "Target": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\DF\\DfX\\DfXBaseFabricTopology.c", 
+        "Timeout": 15
+      }, 
+      {
+        "Name": "GetDeviceMapOnDieUt", 
+        "ConfigFile": "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\DF\\GetDeviceMapOnDie\\GetDeviceMapOnDieUt.json", 
+        "Iterations": ["Default"], 
+        "Target": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\DF\\DfX\\DfXBaseFabricTopology.c", 
+        "Timeout": 15
+      }, 
+      {
+        "Name": "GetHostBridgeBBUt", 
+        "ConfigFile": "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\DF\\GetHostBridgeBB\\GetHostBridgeBBUt.json", 
+        "Iterations": ["NoConditionBranch","ConditionBranch"], 
+        "Target": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\DF\\DfX\\DfXBaseFabricTopology.c", 
+        "Timeout": 15
       }
     ]
   }

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
@@ -199,6 +199,34 @@
         "Iterations": ["NoConditionBranch","ConditionBranch"], 
         "Target": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\DF\\DfX\\DfXBaseFabricTopology.c", 
         "Timeout": 15
+      },
+      {
+        "Name": "GetPhysRootBNUt", 
+        "ConfigFile": "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\DF\\GetPhysRootBN\\GetPhysRootBNUt.json", 
+        "Iterations": ["Default"], 
+        "Target": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\DF\\DfX\\DfXBaseFabricTopology.c", 
+        "Timeout": 15
+      },
+      {
+        "Name": "FindComponentLMUt", 
+        "ConfigFile": "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\DF\\FindComponentLM\\FindComponentLMUt.json", 
+        "Iterations": ["Count", "PhysIos0FabricId"], 
+        "Target": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\DF\\DfX\\DfXBaseFabricTopology.c", 
+        "Timeout": 15
+      },
+      {
+        "Name": "FbrRegstrAccReadUt", 
+        "ConfigFile": "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\DF\\FbrRegstrAccRead\\FbrRegstrAccReadUt.json", 
+        "Iterations": ["InstanceEnter", "InstanceSkip"], 
+        "Target": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\DF\\DfX\\DfXFabricRegisterAcc.c", 
+        "Timeout": 15
+      },
+      {
+        "Name": "FbrRegstrAccWriteUt", 
+        "ConfigFile": "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\DF\\FbrRegstrAccWrite\\FbrRegstrAccWriteUt.json", 
+        "Iterations": ["InstanceEnter", "InstanceSkip"], 
+        "Target": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\DF\\DfX\\DfXFabricRegisterAcc.c", 
+        "Timeout": 15
       }
     ]
   }

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
@@ -101,6 +101,13 @@
         "Iterations": ["ComputeTrue_sCacWeightValidSize", "ComputeFalse"], 
         "Target": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\CCX\\Common\\CcxMiscInit.c", 
         "Timeout": 15
+      }, 
+      {
+        "Name": "CcxInitializeCpbUt", 
+        "ConfigFile": "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\CCX\\CcxInitializeCpb\\CcxInitializeCpbUt.json", 
+        "Iterations": ["CpbEnableTrue", "CpbEnableFalse"], 
+        "Target": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\CCX\\Common\\CcxMiscInit.c", 
+        "Timeout": 15
       }
     ]
   },

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
@@ -86,7 +86,16 @@
   {
     "Component": "CCX",
     "Description": "Profile for xUSL CCX components",
-    "Tests" : []
+    "Tests" : 
+    [
+      {
+        "Name"       : "CcxEnableSmeeUt",
+        "ConfigFile" : "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\CCX\\CcxEnableSmee\\CcxEnableSmeeUt.json",
+        "Iterations" : ["SmeeEnableTrue", "SmeeEnableFalse"],
+        "Target"     : "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\CCX\\Common\\CcxMiscInit.c",
+        "Timeout"    : 15
+      }
+    ]
   },
   {
     "Component": "DF",

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
@@ -227,6 +227,13 @@
         "Iterations": ["InstanceEnter", "InstanceSkip"], 
         "Target": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\DF\\DfX\\DfXFabricRegisterAcc.c", 
         "Timeout": 15
+      },
+      {
+        "Name": "PieRasInitUt", 
+        "ConfigFile": "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\DF\\PieRasInit\\PieRasInitUt.json", 
+        "Iterations": ["AmdFabricWdtCntSel", "HwaStsLowValue", "CtrlInstance"], 
+        "Target": "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\DF\\DfX\\FabricPieRasInit\\FabricPieRasInit.c", 
+        "Timeout": 15
       }
     ]
   }

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxEnableSmee/CcxEnableSmeeUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxEnableSmee/CcxEnableSmeeUt.c
@@ -1,0 +1,141 @@
+/**
+ * @file CcxEnableSmeeUt.c
+ * @brief Unit tests for CcxEnableSmee
+ *
+ * Iterations:
+ *
+ * -Default: Executes CcxEnableSmee(bool)
+ */
+
+#include <UtBaseLib.h>
+#include <UtSilInitLib.h>
+#include <UtLogLib.h>
+
+#include <xSIM.h> 
+#include <Ccx.h>
+#include <MsrReg.h>
+#include <Library/UtMsrRegStubLib.h>
+
+// Stubs 
+bool xUslIsComputeUnitPrimary (
+    void
+    )
+{
+    return true;
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+    
+    bool SmeeEnablePassedValue;
+    if(strcmp(IterationName, "SmeeEnableTrue") == 0)
+    {
+        // Arrange
+        SmeeEnablePassedValue = true; 
+        // Act 
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+        "Call CcxEnableSmee and pass true value");
+        CcxEnableSmee(SmeeEnablePassedValue);
+        // Assert
+    }
+    else if(strcmp(IterationName, "SmeeEnableFalse") == 0)
+    {
+        // Arrange
+        SmeeEnablePassedValue = false; 
+        // Act
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+            "Call CcxEnableSmee and pass false value");
+        CcxEnableSmee(SmeeEnablePassedValue);
+        // Assert
+    }
+    else
+    {
+        Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+            "Iteration '%s' is not implemented.", IterationName);
+        UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+
+    // if we run at any issue, The API is going to abort here.
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+        "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Starting point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  // Logging the start of the test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // Running test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxEnableSmee/CcxEnableSmeeUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxEnableSmee/CcxEnableSmeeUt.inf
@@ -1,0 +1,35 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  CcxEnableSmeeUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = CcxEnableSmeeUt
+  FILE_GUID      = 60B871E5-A37B-456C-A0E8-6587E8E4A59F
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  CcxEnableSmeeUt.c
+  ../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/CCX/Common/CcxMiscInit.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtSilServicesMockLib
+  UtMsrRegStubLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxEnableSmee/CcxEnableSmeeUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxEnableSmee/CcxEnableSmeeUt.json
@@ -1,0 +1,10 @@
+[
+    {
+      "Description": "This Iteration will execute SmeeEnable branch by passing True value to CcxEnableSmee",
+      "Iteration": "SmeeEnableTrue"
+    },
+    {
+      "Description": "This Iteration will not execute SmeeEnable branch by passing False value to CcxEnableSmee",
+      "Iteration": "SmeeEnableFalse"
+    }
+  ]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxInitializeCpb/CcxInitializeCpbUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxInitializeCpb/CcxInitializeCpbUt.c
@@ -1,0 +1,145 @@
+/**
+ * @file CcxInitializeCpbUt.c
+ * @brief Unit tests for CcxInitializeCpbUt
+ *
+ * Iterations:
+ *
+ * -Default: Executes CcxInitializeCpbUt(intuint8_t)
+ */
+
+#include <UtBaseLib.h>
+#include <UtSilInitLib.h>
+#include <UtLogLib.h>
+#include <Library/UtMsrRegStubLib.h>
+
+#include <xSIM.h> 
+#include <Ccx.h>
+#include <MsrReg.h>
+
+// Stubs 
+bool xUslIsComputeUnitPrimary (
+    void
+    )
+{
+    return true;
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+    AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+    const char* TestName        = UtGetTestName (Ut);
+    const char* IterationName   = UtGetTestIteration (Ut);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+        "%s (Iteration: %s) Test started.", TestName, IterationName);    
+
+    uint8_t CpbEnable; 
+    // Iterations:
+    if(strcmp(IterationName, "CpbEnableTrue") == 0)
+    {
+        // Arrange
+        CpbEnable = 1; 
+        // Act
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__,
+            "Call CcxInitializeCpb and pass 1 value");
+        CcxInitializeCpb(CpbEnable);
+        // Assert
+        // The function is void 
+    }
+    else if(strcmp(IterationName, "CpbEnableFalse") == 0)
+    {
+        // Arrange
+        CpbEnable = 0; 
+        // Act
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+            "Call CcxInitializeCpb and pass 0 value");
+        CcxInitializeCpb(CpbEnable);
+        // Assert
+        // The function is void 
+    }
+    else
+    {
+        Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+            "Iteration '%s' is not implemented.", IterationName);
+        UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);        
+    }
+
+    // if we run at any issue, The API is going to abort here.
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+        "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Starting point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  // Logging the start of the test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // Running test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}
+

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxInitializeCpb/CcxInitializeCpbUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxInitializeCpb/CcxInitializeCpbUt.inf
@@ -1,0 +1,35 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  CcxInitializeCpbUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = CcxInitializeCpbUt
+  FILE_GUID      = F942EE2A-E27E-412C-82F2-82CE1DCDBFB9
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  CcxInitializeCpbUt.c
+  ../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/CCX/Common/CcxMiscInit.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtSilServicesMockLib
+  UtMsrRegStubLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxInitializeCpb/CcxInitializeCpbUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxInitializeCpb/CcxInitializeCpbUt.json
@@ -1,0 +1,10 @@
+[
+{
+    "Description": "This iteration will execute CpbEnable branch by passing 1 value to CcxInitializeCpb", 
+    "Iteration": "CpbEnableTrue"
+},
+{
+    "Description": "This iteration will execute CpbEnable branch by passing 0 value to CcxInitializeCpb", 
+    "Iteration": "CpbEnableFalse"
+}
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSetCacWeights/CcxSetCacWeightsUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSetCacWeights/CcxSetCacWeightsUt.c
@@ -1,0 +1,140 @@
+/**
+ * @file CcxSetCacWeightsUt.c
+ * @brief Unit tests for CcxSetCacWeightsUt
+ *
+ * Iterations:
+ *
+ * -Default: Executes CcxSetCacWeightsUt
+ */
+#include <SilCommon.h> 
+
+#include <UtBaseLib.h>
+#include <UtSilInitLib.h>
+#include <UtLogLib.h>
+
+#include <Library/UtSilServicesMockLib.h>
+#include <Library/UtxUslCcxRolesMockLib.h>
+#include <Library/UtMsrRegStubLib.h>
+
+#include <xSIM.h> 
+#include <Ccx.h>
+#include <MsrReg.h> 
+
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+   
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+    
+    if(strcmp(IterationName, "ComputeFalse") == 0)
+    {
+        // Arrange
+        uint64_t* sCacWeightNull = NULL;
+        MockxUslIsComputeUnitPrimary(false);  
+        // Act 
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+        "Do not enter xUslIsComputeUnitPrimary branch");
+        CcxSetCacWeights(sCacWeightNull);
+        // Assert
+    }
+    else if(strcmp(IterationName, "ComputeTrue_sCacWeightValidSize") == 0)
+    {
+        // Arrange
+        uint64_t sCacWeightValid[MAX_CAC_WEIGHT_NUM] = {0};
+        MockxUslIsComputeUnitPrimary(true);
+        // Act
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+            "Enter the xUslIsComputeUnitPrimary branch with valid array");
+        CcxSetCacWeights(sCacWeightValid);
+        // Assert
+    }
+    else
+    {
+        Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+            "Iteration '%s' is not implemented.", IterationName);
+        UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+
+    // if we run at any issue, The API is going to abort here.
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+        "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Starting point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  // Logging the start of the test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // Running test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSetCacWeights/CcxSetCacWeightsUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSetCacWeights/CcxSetCacWeightsUt.inf
@@ -1,0 +1,36 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  CcxSetCacWeightsUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = CcxSetCacWeightsUt
+  FILE_GUID      = F942EE2A-E27E-412C-82F2-82CE1DCDBFB9
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  CcxSetCacWeightsUt.c
+  ../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/CCX/Common/CcxMiscInit.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtxUslCcxRolesMockLib
+  UtSilServicesMockLib
+  UtMsrRegStubLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSetCacWeights/CcxSetCacWeightsUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSetCacWeights/CcxSetCacWeightsUt.json
@@ -1,0 +1,11 @@
+[
+    {
+        "Description": "This iteration will execute xUslIsComputeUnitPrimary branch by mocking true return value. It passes sCacWeight of size 23", 
+        "Iteration": "ComputeTrue_sCacWeightValidSize"
+    },
+    {
+        "Description": "This iteration will execute  xUslIsComputeUnitPrimary branch by mocking false return value", 
+        "Iteration": "ComputeFalse"
+    }
+    ]
+

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSetMiscMsrs/CcxSetMiscMsrsUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSetMiscMsrs/CcxSetMiscMsrsUt.c
@@ -1,0 +1,176 @@
+/**
+ * @file CcxSetMiscMsrsUt.c
+ * @brief Unit tests for CcxSetMiscMsrs
+ *
+ * Iterations:
+ *
+ * -Default: Executes CcxSetMiscMsrsUt(CCXCLASS_INPUT_BLK)
+ */
+
+#include <UtBaseLib.h>
+#include <UtSilInitLib.h>
+#include <UtLogLib.h>
+
+#include <xSIM.h> 
+#include <Ccx.h>
+#include <MsrReg.h>
+#include <CcxCmn2Rev.h>
+
+#include <Library/UtMsrRegStubLib.h>
+#include <Library/UtSilServicesMockLib.h>
+#include <xSIM-api.h>
+
+// Stubs 
+bool xUslIsComputeUnitPrimary (
+    void
+    )
+{
+    return true;
+}
+
+void
+Zen4SetMiscMsrs (
+  CCXCLASS_INPUT_BLK *CcxInputBlock
+  )
+{
+    return; 
+}
+
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+    
+    if(strcmp(IterationName, "ZeroInitialized") == 0)
+    {
+        // Arrange
+        CCX_XFER_TABLE CcxXferZen4 = {0};          // table 
+        CcxXferZen4.SetMiscMsrs = Zen4SetMiscMsrs; // function is called in CcxSetMiscMsrs. assign stub
+
+        MockSilGetCommon2RevXferTableOnce(&CcxXferZen4, SilPass); // mock with proper table and status
+
+        CCXCLASS_INPUT_BLK CcxInputBlock = {0}; // 0 initialized argument. will skip EnableSvmAVIC branch 
+        // Act 
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+        "Call CcxSetMiscMsrs and pass zero initialized CcxInputBlock");
+        CcxSetMiscMsrs (&CcxInputBlock);
+        // Assert
+    }
+    else if(strcmp(IterationName, "ZeroInitialized_EnableSvmAVIC") == 0)
+    {
+        // Arrange
+        CCX_XFER_TABLE CcxXferZen4 = {0};           // table
+        CcxXferZen4.SetMiscMsrs = Zen4SetMiscMsrs;  // function is called in CcxSetMiscMsrs. assign stub
+
+        MockSilGetCommon2RevXferTableOnce(&CcxXferZen4, SilPass);  // mock with proper table and status
+
+        CCXCLASS_INPUT_BLK CcxInputBlock = {0};  // 0 initialized argument 
+        CcxInputBlock.EnableSvmAVIC = true;      // set to true to enter EnableSvmAVIC branch 
+        // Act
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+            "Call CcxSetMiscMsrs and pass zero initialized CcxInputBlock with EnableSvmAVIC set to true");
+        CcxSetMiscMsrs (&CcxInputBlock);
+        // Assert
+    }
+    else if(strcmp(IterationName, "SilAborted") == 0)
+    {
+        // Arrange
+        MockSilGetCommon2RevXferTableOnce(NULL, SilAborted); // mock with null table and error status
+        
+        CCXCLASS_INPUT_BLK CcxInputBlock = {0};  // 0 initialized argument 
+        // Act
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+            "Call CcxSetMiscMsrs. Mock CcxXferZen4 table as invalid");
+        CcxSetMiscMsrs (&CcxInputBlock);
+        // Assert
+    }
+    else
+    {
+        Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+            "Iteration '%s' is not implemented.", IterationName);
+        UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+
+    // if we run at any issue, The API is going to abort here.
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+        "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Starting point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  // Logging the start of the test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // Running test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSetMiscMsrs/CcxSetMiscMsrsUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSetMiscMsrs/CcxSetMiscMsrsUt.inf
@@ -1,0 +1,35 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  CcxSetMiscMsrsUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = CcxSetMiscMsrsUt
+  FILE_GUID      = F7E9E2DA-A727-4B7D-9BD1-D30642277955
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  CcxSetMiscMsrsUt.c
+  ../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/CCX/Common/CcxMiscInit.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtSilServicesMockLib
+  UtMsrRegStubLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSetMiscMsrs/CcxSetMiscMsrsUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSetMiscMsrs/CcxSetMiscMsrsUt.json
@@ -1,0 +1,14 @@
+[
+    {
+      "Description": "This Iteration will execute CcxSetMiscMsrsUt branch by passing zero initialized CcxInputBlock",
+      "Iteration": "ZeroInitialized"
+    }, 
+    {
+      "Description": "This Iteration will execute CcxSetMiscMsrsUt branch by passing zero initialized CcxInputBlock with EnableSvmAVIC set to true",
+      "Iteration": "ZeroInitialized_EnableSvmAVIC"
+    }, 
+    {
+      "Description": "This Iteration will execute CcxSetMiscMsrsUt branch by passing SilAborted",
+      "Iteration": "SilAborted"
+    }
+  ]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSyncMiscMsrs/CcxSyncMiscMsrsUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSyncMiscMsrs/CcxSyncMiscMsrsUt.c
@@ -1,0 +1,134 @@
+/**
+ * @file CcxSyncMiscMsrsUt.c
+ * @brief Unit tests for CcxSyncMiscMsrs
+ *
+ * Iterations:
+ *
+ * -Default: Executes CcxSyncMiscMsrs (volatile AMD_CCX_AP_LAUNCH_GLOBAL_DATA)
+ */
+
+#include <UtBaseLib.h>
+#include <UtSilInitLib.h>
+#include <UtLogLib.h>
+
+#include <xSIM.h> 
+#include <Ccx.h>
+#include <MsrReg.h>
+#include <Library/UtMsrRegStubLib.h>
+
+// Stubs 
+bool xUslIsComputeUnitPrimary (
+    void
+    )
+{
+    return true;
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+    
+    if(strcmp(IterationName, "ZeroInitialized_InputStruct") == 0)
+    {
+        // Arrange
+        volatile AP_MSR_SYNC passedApMsrSyncList[3] = {0}; 
+        passedApMsrSyncList[2].MsrAddr = CPU_LIST_TERMINAL; // will terminate at this address
+
+        AMD_CCX_AP_LAUNCH_GLOBAL_DATA passedApLaunchGlobalData = {0};
+        passedApLaunchGlobalData.ApMsrSyncList = passedApMsrSyncList; 
+        // Act 
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+        "Call CcxSyncMiscMsrs and pass zero initialized AMD_CCX_AP_LAUNCH_GLOBAL_DATA");
+        CcxSyncMiscMsrs (&passedApLaunchGlobalData);
+        // Assert
+    }
+    else
+    {
+        Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+            "Iteration '%s' is not implemented.", IterationName);
+        UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+
+    // if we run at any issue, The API is going to abort here.
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+        "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Starting point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  // Logging the start of the test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // Running test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSyncMiscMsrs/CcxSyncMiscMsrsUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSyncMiscMsrs/CcxSyncMiscMsrsUt.inf
@@ -1,0 +1,35 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  CcxSyncMiscMsrsUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = CcxSyncMiscMsrsUt
+  FILE_GUID      = 67231A0D-E0F9-4C55-A948-F4DDA09E14B5
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  CcxSyncMiscMsrsUt.c
+  ../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/CCX/Common/CcxMiscInit.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtSilServicesMockLib
+  UtMsrRegStubLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSyncMiscMsrs/CcxSyncMiscMsrsUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSyncMiscMsrs/CcxSyncMiscMsrsUt.json
@@ -1,0 +1,6 @@
+[
+    {
+      "Description": "This Iteration will execute CcxSyncMiscMsrs branch by passing zero initialized AMD_CCX_AP_LAUNCH_GLOBAL_DATA",
+      "Iteration": "ZeroInitialized_InputStruct"
+    }
+  ]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/AmdOpenSilUtPkgGn.dsc.inc
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/AmdOpenSilUtPkgGn.dsc.inc
@@ -1,0 +1,37 @@
+## @file
+# AMD OpenSIL PHX Host Unit Test Package DSC Include File
+#
+# Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+##
+
+!include AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dsc.inc
+
+[Defines]
+  #
+
+[LibraryClasses.common.HOST_APPLICATION]
+
+
+[Components.common.HOST_APPLICATION]
+
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/Xmp/SilHelloWorldUt/SilHelloWorldUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Fch/FchAb/FchInitResetAbUt/FchInitResetAbUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Fch/FchAb/FchAbSetInputBlkUt/FchAbSetInputBlkUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Fch/FchAb/FchInitEnvAbUt/FchInitEnvAbUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxEnableSmee/CcxEnableSmeeUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxInitializeCpb/CcxInitializeCpbUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSetCacWeights/CcxSetCacWeightsUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSyncMiscMsrs/CcxSyncMiscMsrsUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/CCX/CcxSetMiscMsrs/CcxSetMiscMsrsUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/TypeEntryInMap/TypeEntryInMapUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/RootBridgeInfo/RootBridgeInfoUt.inf  
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfProcessors/NumberOfProcessorsUt.inf  
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfSystemDies/NumberOfSystemDiesUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfSystemRB/NumberOfSystemRBUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfRBOnS/NumberOfRBOnSUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfRBOnD/NumberOfRBOnDUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetDieSystemOffset/GetDieSystemOffsetUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetDeviceMapOnDie/GetDeviceMapOnDieUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetHostBridgeBB/GetHostBridgeBBUt.inf

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/FbrRegstrAccRead/FbrRegstrAccReadUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/FbrRegstrAccRead/FbrRegstrAccReadUt.c
@@ -1,0 +1,164 @@
+/**
+ * @file  FbrRegstrAccReadUt.c
+ * @brief Unit tests for DfXFabricRegisterAccRead
+ *
+ * Iterations:
+ * - InstanceEnter: Call DfXFabricRegisterAccRead and enter Instance branch
+ *   
+ * - InstanceSkip: Call DfXFabricRegisterAccRead and skip Instance branch
+ */
+
+
+#include <UtBaseLib.h>
+#include <UtLogLib.h>
+
+#include <OpenSIL\xUSL\DF\DfIp2Ip.h> // Can not recognize DfIp2Ip.h without relative path 
+#include "DfXFabricRegisterAcc.h"
+
+// Stubs:
+uint32_t xUSLPciRead32 (uint32_t Address)
+{
+    return 0;
+}
+void xUSLPciWrite32 (uint32_t Address, uint32_t Value)
+{
+    return; 
+}
+uint32_t
+DfFabricRegisterAccGetPciDeviceNumberOfDie (
+  uint32_t Socket
+  )
+{
+    return 0; 
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+    
+    if(strcmp(IterationName, "InstanceEnter") == 0)
+    {
+        // Arrange
+        uint32_t Socket = 0;
+        uint32_t Function = 0;
+        uint32_t Offset = 0;
+        uint32_t Instance = FABRIC_REG_ACC_BC;
+
+        uint32_t result; 
+        // Act 
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+        "Call DfXFabricRegisterAccRead");
+        result =  DfXFabricRegisterAccRead(Socket, Function, Offset, Instance);
+        // Assert
+        if(result != 0) 
+          UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+
+    }
+    else if(strcmp(IterationName, "InstanceSkip") == 0)
+    {
+        // Arrange
+        uint32_t Socket = 0;
+        uint32_t Function = 0;
+        uint32_t Offset = 0;
+        uint32_t Instance = 0;
+
+        uint32_t result; 
+        // Act 
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+        "Call DfXFabricRegisterAccRead");
+        result =  DfXFabricRegisterAccRead(Socket, Function, Offset, Instance);
+        // Assert
+        if(result != 0) 
+          UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+
+    }
+    else
+    {
+        Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+            "Iteration '%s' is not implemented.", IterationName);
+        UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+
+    // if we run at any issue, The API is going to abort here.
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+        "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Starting point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  // Logging the start of the test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // Running test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/FbrRegstrAccRead/FbrRegstrAccReadUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/FbrRegstrAccRead/FbrRegstrAccReadUt.inf
@@ -1,0 +1,34 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  FbrRegstrAccReadUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = FbrRegstrAccReadUt
+  FILE_GUID      = F11DD60C-EA61-4DD4-9251-CCD1AE4A5A95
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  FbrRegstrAccReadUt.c
+  ../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/DF/DfX/DfXFabricRegisterAcc.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtSilServicesMockLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/FbrRegstrAccRead/FbrRegstrAccReadUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/FbrRegstrAccRead/FbrRegstrAccReadUt.json
@@ -1,0 +1,9 @@
+[   {
+    "Description": "This Iteration will execute DfXFabricRegisterAccRead and enter Instance branch",
+    "Iteration": "InstanceEnter"
+    }, 
+    {
+    "Description": "This Iteration will execute DfXFabricRegisterAccRead and skip Instance branch",
+    "Iteration": "InstanceSkip"
+    }
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/FbrRegstrAccWrite/FbrRegstrAccWriteUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/FbrRegstrAccWrite/FbrRegstrAccWriteUt.c
@@ -1,0 +1,159 @@
+/**
+ * @file  FbrRegstrAccWriteUt.c
+ * @brief Unit tests for DfXFabricRegisterAccWrite
+ *
+ * Iterations:
+ * - InstanceEnter: Call DfXFabricRegisterAccWrite and enter Instance branch
+ *   
+ * - InstanceSkip: Call DfXFabricRegisterAccWrite and skip Instance branch
+ */
+
+
+#include <UtBaseLib.h>
+#include <UtLogLib.h>
+
+#include <OpenSIL\xUSL\DF\DfIp2Ip.h> // Can not recognize DfIp2Ip.h without relative path 
+#include "DfXFabricRegisterAcc.h"
+
+// Stubs:
+uint32_t xUSLPciRead32 (uint32_t Address)
+{
+    return 0;
+}
+void xUSLPciWrite32 (uint32_t Address, uint32_t Value)
+{
+    return; 
+}
+uint32_t
+DfFabricRegisterAccGetPciDeviceNumberOfDie (
+  uint32_t Socket
+  )
+{
+    return 0; 
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+    
+    if(strcmp(IterationName, "InstanceEnter") == 0)
+    {
+        // Arrange
+        uint32_t Socket = 0;
+        uint32_t Function = 0;
+        uint32_t Offset = 0;
+        uint32_t Instance = FABRIC_REG_ACC_BC;
+        uint32_t Value = 0; 
+
+        // Act 
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+        "Call DfXFabricRegisterAccWrite");
+        DfXFabricRegisterAccWrite(Socket, Function, Offset, Instance, Value);
+        // Assert
+
+    }
+    else if(strcmp(IterationName, "InstanceSkip") == 0)
+    {
+        // Arrange
+        uint32_t Socket = 0;
+        uint32_t Function = 0;
+        uint32_t Offset = 0;
+        uint32_t Instance = 0;
+        uint32_t Value = 0; 
+
+        // Act 
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+        "Call DfXFabricRegisterAccWrite");
+        DfXFabricRegisterAccWrite(Socket, Function, Offset, Instance, Value);
+
+    }
+    else
+    {
+        Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+            "Iteration '%s' is not implemented.", IterationName);
+        UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+
+    // if we run at any issue, The API is going to abort here.
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+        "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Starting point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  // Logging the start of the test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // Running test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/FbrRegstrAccWrite/FbrRegstrAccWriteUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/FbrRegstrAccWrite/FbrRegstrAccWriteUt.inf
@@ -1,0 +1,34 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  FbrRegstrAccWriteUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = FbrRegstrAccWriteUt
+  FILE_GUID      = F11DD60C-EA61-4DD4-9251-CCD1AE4A5A95
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  FbrRegstrAccWriteUt.c
+  ../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/DF/DfX/DfXFabricRegisterAcc.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtSilServicesMockLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/FbrRegstrAccWrite/FbrRegstrAccWriteUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/FbrRegstrAccWrite/FbrRegstrAccWriteUt.json
@@ -1,0 +1,9 @@
+[   {
+    "Description": "This Iteration will execute DfXFabricRegisterAccRead and enter Instance branch",
+    "Iteration": "InstanceEnter"
+    }, 
+    {
+    "Description": "This Iteration will execute DfXFabricRegisterAccRead and skip Instance branch",
+    "Iteration": "InstanceSkip"
+    }
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/FindComponentLM/FindComponentLMUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/FindComponentLM/FindComponentLMUt.c
@@ -1,0 +1,205 @@
+/**
+ * @file  FindComponentLM.c
+ * @brief Unit tests for DfXFindComponentLocationMap
+ *
+ * Iterations:
+ * - NoConditionBranch: Call DfXFindComponentLocationMap and skip the if branch through a mock call
+ *   
+ * - ConditionBranch: Call DfXFindComponentLocationMap and enter the if branch through a mock call
+ */
+
+
+#include <UtBaseLib.h>
+#include <UtLogLib.h>
+#include <stdlib.h>
+
+#include <OpenSIL\xUSL\DF\DfIp2Ip.h> // Can not recognize DfIp2Ip.h without relative path 
+#include "DfXBaseFabricTopology.h"
+
+// Mocks:
+static int num = 0; 
+uint32_t
+DfXFabricRegisterAccRead (
+  uint32_t Socket,
+  uint32_t Function,
+  uint32_t Offset,
+  uint32_t Instance
+  )
+{
+    if(num == 0)
+    {
+        return 0x00000303;
+    }
+    else
+         return 0x00000000;
+}
+
+// Stubs: 
+uint32_t DfGetNumberOfDiesOnSocket (void)
+{
+  return 0; 
+}
+
+uint32_t
+DfGetHostBridgeSystemFabricID (
+  uint32_t Socket,
+  uint32_t Index
+  )
+{
+  return 771;
+}
+
+// Fakes: 
+const
+AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP *
+DfFindDeviceTypeEntryInMap (
+  FABRIC_DEVICE_TYPE  Type
+  )
+{
+    static const DEVICE_IDS myIds[1] = {0}; // Mock device IDs.
+    static const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP myMap[1] = 
+    {
+        {
+            Ios,       // Device type.
+            0,         // Device count.
+            myIds      // Associated device IDs...
+        }
+    };
+    return myMap; // Returns a mock device map for testing.
+}
+
+const COMPONENT_LOCATION  TestGenoaComponentLocation [] = {
+  {0, 0, 0x22, PrimaryFch}, // Physical location, Socket 0, Die 0, Ios2
+  {1, 0, 0x22, SecondaryFch},   // Physical location, Socket 1, Die 0, Ios2
+  {0, 0, 0x22, PrimarySmu}, // Physical location, Socket 0, Die 0, Ios2
+  {1, 0, 0x22, SecondarySmu},   // Physical location, Socket 1, Die 0, Ios2
+};
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+    
+    if(strcmp(IterationName, "Count") == 0)
+    {
+        // Arrange
+
+        num = 1;
+        uint32_t *Count = (uint32_t *)malloc(sizeof(uint32_t));
+        uint32_t *PhysIos0FabricId = NULL;
+        const COMPONENT_LOCATION* result = &TestGenoaComponentLocation[0];
+        // Act 
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+        "Call DfXFindComponentLocationMap");
+        result = DfXFindComponentLocationMap(Count, PhysIos0FabricId);
+        // Assert
+        if(result->Socket != 0 || result->Die != 0 ||
+           result->IomsFabricId != 0x22 || result->Type != PrimaryFch) 
+          UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+
+    }
+    else if(strcmp(IterationName, "PhysIos0FabricId") == 0)
+    {
+        // Arrange
+        uint32_t *Count = NULL;
+        uint32_t *PhysIos0FabricId = (uint32_t *)malloc(sizeof(uint32_t));
+        const COMPONENT_LOCATION* result = &TestGenoaComponentLocation[0];
+        // Act 
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+        "Call DfXFindComponentLocationMap");
+        result = DfXFindComponentLocationMap(Count, PhysIos0FabricId);
+        // Assert
+        if(result->Socket != 0 || result->Die != 0 ||
+           result->IomsFabricId != 0x22 || result->Type != PrimaryFch) 
+          UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+
+    }
+    else
+    {
+        Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+            "Iteration '%s' is not implemented.", IterationName);
+        UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+
+    // if we run at any issue, The API is going to abort here.
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+        "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Starting point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  // Logging the start of the test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // Running test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/FindComponentLM/FindComponentLMUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/FindComponentLM/FindComponentLMUt.inf
@@ -1,0 +1,34 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  FindComponentLMUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = FindComponentLMUt
+  FILE_GUID      = F11DD60C-EA61-4DD4-9251-CCD1AE4A5A95
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  FindComponentLMUt.c
+  ../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/DF/DfX/DfXBaseFabricTopology.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtSilServicesMockLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/FindComponentLM/FindComponentLMUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/FindComponentLM/FindComponentLMUt.json
@@ -1,0 +1,9 @@
+[   {
+    "Description": "This Iteration will execute DfXFindComponentLocationMap and enter Count branch",
+    "Iteration": "Count"
+    },
+    {
+      "Description": "This Iteration will execute DfXFindComponentLocationMap and enter PhysIos0FabricId branch",
+      "Iteration": "PhysIos0FabricId"
+    }
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetDeviceMapOnDie/GetDeviceMapOnDieUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetDeviceMapOnDie/GetDeviceMapOnDieUt.c
@@ -1,0 +1,203 @@
+/**
+ * @file GetDeviceMapOnDieUt.c
+ * @brief Unit tests for DfXGetDeviceMapOnDie
+ *
+ * Iterations:
+ * -Default: Calls the DfXGetDeviceMapOnDie function and stores the returned value. 
+ *           Verififes whether the returned value is as expected. 
+ *
+ */
+
+
+#include <UtBaseLib.h>
+#include <UtLogLib.h>
+
+#include <OpenSIL\xUSL\DF\DfIp2Ip.h> // Can not recognize DfIp2Ip.h without relative path 
+#include "DfXBaseFabricTopology.h"
+
+// Fakes:
+uint32_t
+DfXFabricRegisterAccRead (
+  uint32_t Socket,
+  uint32_t Function,
+  uint32_t Offset,
+  uint32_t Instance
+  )
+{
+    return 1; 
+}
+
+uint32_t DfGetNumberOfDiesOnSocket (void)
+{
+  return 1; 
+}
+
+uint32_t
+DfGetHostBridgeSystemFabricID (
+  uint32_t Socket,
+  uint32_t Index
+  )
+{
+  return 1;
+}
+
+const
+AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP *
+DfFindDeviceTypeEntryInMap (
+  FABRIC_DEVICE_TYPE  Type
+  )
+{
+    static const DEVICE_IDS myIds[1] = {0}; // Mock device IDs.
+    static const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP myMap[1] = 
+    {
+        {
+            Ios,       // Device type.
+            0,         // Device count.
+            myIds      // Associated device IDs...
+        }
+    };
+    return myMap; // Returns a mock device map for testing.
+}
+
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+    
+    if(strcmp(IterationName, "Default") == 0)
+    {
+        // Arrange
+        const DEVICE_IDS   GenoaCsMap [] = 
+        {
+            {0x00000000, 0x00000000},
+            {0x00000001, 0x00000001},
+            {0x00000002, 0x00000002},
+            {0x00000003, 0x00000003},
+            {0x00000004, 0x00000004},
+            {0x00000005, 0x00000005},
+            {0x00000006, 0x00000006},
+            {0x00000007, 0x00000007},
+            {0x00000008, 0x00000008},
+            {0x00000009, 0x00000009},
+            {0x0000000A, 0x0000000A},
+            {0x0000000B, 0x0000000B},
+            {0x0000000C, 0x0000000C},
+            {0x0000000D, 0x0000000D},
+            {0x0000000E, 0x0000000E},
+            {0x0000000F, 0x0000000F}
+        };
+        const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP DeviceMap = 
+        {   
+            Cs,
+            sizeof(GenoaCsMap) / sizeof(GenoaCsMap[0]),
+            &GenoaCsMap[0]
+        };
+        const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP* result;
+        // Act 
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+        "Call DfXGetDeviceMapOnDie");
+        result = DfXGetDeviceMapOnDie();
+        // Assert
+        if(DeviceMap.Type != result->Type || DeviceMap.Count != result->Count) 
+          UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+        
+        for (size_t i = 0; i < DeviceMap.Count; i++) 
+        {
+            if (DeviceMap.IDs[i].FabricID != result->IDs[i].FabricID ||
+                DeviceMap.IDs[i].InstanceID != result->IDs[i].InstanceID) 
+                {
+                    UtSetTestStatus(Ut, AMD_UNIT_TEST_ABORTED);
+                    break;
+                }
+        }
+    }
+    else
+    {
+        Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+            "Iteration '%s' is not implemented.", IterationName);
+        UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+
+    // if we run at any issue, The API is going to abort here.
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+        "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Starting point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  // Logging the start of the test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // Running test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetDeviceMapOnDie/GetDeviceMapOnDieUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetDeviceMapOnDie/GetDeviceMapOnDieUt.inf
@@ -1,0 +1,34 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  GetDeviceMapOnDieUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = GetDeviceMapOnDieUt
+  FILE_GUID      = F11DD60C-EA61-4DD4-9251-CCD1AE4A5A95
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  GetDeviceMapOnDieUt.c
+  ../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/DF/DfX/DfXBaseFabricTopology.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtSilServicesMockLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetDeviceMapOnDie/GetDeviceMapOnDieUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetDeviceMapOnDie/GetDeviceMapOnDieUt.json
@@ -1,0 +1,6 @@
+[
+    {
+      "Description": "Call the DfXGetDeviceMapOnDie function",
+      "Iteration": "Default"
+    }
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetDieSystemOffset/GetDieSystemOffsetUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetDieSystemOffset/GetDieSystemOffsetUt.c
@@ -1,0 +1,170 @@
+/**
+ * @file GetDieSystemOffsetUt.c
+ * @brief Unit tests for DfXGetDieSystemOffset
+ *
+ * Iterations:
+ * -Default: Calls the DfXGetDieSystemOffset function and stores the returned value. 
+ *           Verififes whether the returned value is as expected. 
+ *
+ */
+
+
+#include <UtBaseLib.h>
+#include <UtLogLib.h>
+
+#include <OpenSIL\xUSL\DF\DfIp2Ip.h> // Can not recognize DfIp2Ip.h without relative path 
+#include "DfXBaseFabricTopology.h"
+
+// Fakes:
+uint32_t
+DfXFabricRegisterAccRead (
+  uint32_t Socket,
+  uint32_t Function,
+  uint32_t Offset,
+  uint32_t Instance
+  )
+{
+    return 1; 
+}
+
+uint32_t DfGetNumberOfDiesOnSocket (void)
+{
+  return 1; 
+}
+
+uint32_t
+DfGetHostBridgeSystemFabricID (
+  uint32_t Socket,
+  uint32_t Index
+  )
+{
+  return 1;
+}
+
+const
+AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP *
+DfFindDeviceTypeEntryInMap (
+  FABRIC_DEVICE_TYPE  Type
+  )
+{
+    static const DEVICE_IDS myIds[1] = {0}; // Mock device IDs.
+    static const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP myMap[1] = 
+    {
+        {
+            Ios,       // Device type.
+            0,         // Device count.
+            myIds      // Associated device IDs...
+        }
+    };
+    return myMap; // Returns a mock device map for testing.
+}
+
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+    
+    if(strcmp(IterationName, "Default") == 0)
+    {
+        // Arrange
+        uint32_t result;
+        uint32_t Socket = 1; 
+        // Act 
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+        "Call DfXGetDieSystemOffset");
+        result = DfXGetDieSystemOffset(Socket);
+        // Assert
+        if(result != 256) 
+          UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+
+    }
+    else
+    {
+        Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+            "Iteration '%s' is not implemented.", IterationName);
+        UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+
+    // if we run at any issue, The API is going to abort here.
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+        "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Starting point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  // Logging the start of the test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // Running test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetDieSystemOffset/GetDieSystemOffsetUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetDieSystemOffset/GetDieSystemOffsetUt.inf
@@ -1,0 +1,34 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  GetDieSystemOffsetUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = GetDieSystemOffsetUt
+  FILE_GUID      = F11DD60C-EA61-4DD4-9251-CCD1AE4A5A95
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  GetDieSystemOffsetUt.c
+  ../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/DF/DfX/DfXBaseFabricTopology.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtSilServicesMockLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetDieSystemOffset/GetDieSystemOffsetUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetDieSystemOffset/GetDieSystemOffsetUt.json
@@ -1,0 +1,6 @@
+[
+    {
+      "Description": "Call the DfXGetDieSystemOffset function",
+      "Iteration": "Default"
+    }
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetHostBridgeBB/GetHostBridgeBBUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetHostBridgeBB/GetHostBridgeBBUt.c
@@ -1,0 +1,191 @@
+/**
+ * @file  GetHostBridgeBBUt.c
+ * @brief Unit tests for DfXGetHostBridgeBusBase
+ *
+ * Iterations:
+ * - NoConditionBranch: Call DfXGetHostBridgeBusBase and skip the if branch through a mock call
+ *   
+ * - ConditionBranch: Call DfXGetHostBridgeBusBase and enter the if branch through a mock call
+ */
+
+
+#include <UtBaseLib.h>
+#include <UtLogLib.h>
+
+#include <OpenSIL\xUSL\DF\DfIp2Ip.h> // Can not recognize DfIp2Ip.h without relative path 
+#include "DfXBaseFabricTopology.h"
+
+// Mocks:
+static int num = 0; 
+uint32_t
+DfXFabricRegisterAccRead (
+  uint32_t Socket,
+  uint32_t Function,
+  uint32_t Offset,
+  uint32_t Instance
+  )
+{
+    if(num == 0)
+    {
+        return 0x00000303;
+    }
+    else
+         return 0x00000000;
+}
+
+// Stubs: 
+uint32_t DfGetNumberOfDiesOnSocket (void)
+{
+  return 0; 
+}
+
+uint32_t
+DfGetHostBridgeSystemFabricID (
+  uint32_t Socket,
+  uint32_t Index
+  )
+{
+  return 771;
+}
+
+// Fakes: 
+const
+AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP *
+DfFindDeviceTypeEntryInMap (
+  FABRIC_DEVICE_TYPE  Type
+  )
+{
+    static const DEVICE_IDS myIds[1] = {0}; // Mock device IDs.
+    static const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP myMap[1] = 
+    {
+        {
+            Ios,       // Device type.
+            0,         // Device count.
+            myIds      // Associated device IDs...
+        }
+    };
+    return myMap; // Returns a mock device map for testing.
+}
+
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+    
+    if(strcmp(IterationName, "NoConditionBranch") == 0)
+    {
+        // Arrange
+        num = 1; // mock flag 
+        uint32_t Socket = 1;
+        uint32_t Index = 1; 
+        uint32_t result;
+
+        // Act 
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+        "Call DfXGetHostBridgeBusBase");
+        result = DfXGetHostBridgeBusBase(Socket, Index);
+        // Assert
+        if(result != 4294967295) 
+          UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+
+    }
+    if(strcmp(IterationName, "ConditionBranch") == 0)
+    {
+        // Arrange
+        num = 0; // mock flag 
+        uint32_t Socket = 1;
+        uint32_t Index = 1; 
+        uint32_t result;
+        // Act 
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+        "Call DfXGetHostBridgeBusBase");
+        result = DfXGetHostBridgeBusBase(Socket, Index);
+        // Assert
+        if(result != 768) 
+          UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+
+    }
+
+    // if we run at any issue, The API is going to abort here.
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+        "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Starting point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  // Logging the start of the test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // Running test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetHostBridgeBB/GetHostBridgeBBUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetHostBridgeBB/GetHostBridgeBBUt.inf
@@ -1,0 +1,34 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  GetHostBridgeBBUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = GetHostBridgeBBUt
+  FILE_GUID      = F11DD60C-EA61-4DD4-9251-CCD1AE4A5A95
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  GetHostBridgeBBUt.c
+  ../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/DF/DfX/DfXBaseFabricTopology.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtSilServicesMockLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetHostBridgeBB/GetHostBridgeBBUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetHostBridgeBB/GetHostBridgeBBUt.json
@@ -1,0 +1,9 @@
+[   {
+    "Description": "This Iteration will execute DfXGetHostBridgeBusBase and return default",
+    "Iteration": "NoConditionBranch"
+    },
+    {
+      "Description": "This Iteration will execute DfXGetHostBridgeBusBase and enter condition branch",
+      "Iteration": "ConditionBranch"
+    }
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetHostBridgeBL/GetHostBridgeBLUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetHostBridgeBL/GetHostBridgeBLUt.c
@@ -1,0 +1,197 @@
+/**
+ * @file  GetHostBridgeBLUt.c
+ * @brief Unit tests for DfXGetHostBridgeBusLimit
+ *
+ * Iterations:
+ * - NoConditionBranch: Call DfXGetHostBridgeBusLimit and skip the if branch through a mock call
+ *   
+ * - ConditionBranch: Call DfXGetHostBridgeBusLimit and enter the if branch through a mock call
+ */
+
+
+#include <UtBaseLib.h>
+#include <UtLogLib.h>
+
+#include <OpenSIL\xUSL\DF\DfIp2Ip.h> // Can not recognize DfIp2Ip.h without relative path 
+#include "DfXBaseFabricTopology.h"
+
+// Mocks:
+static int num = 0; 
+uint32_t
+DfXFabricRegisterAccRead (
+  uint32_t Socket,
+  uint32_t Function,
+  uint32_t Offset,
+  uint32_t Instance
+  )
+{
+    if(num == 0)
+    {
+        return 0x00000303;
+    }
+    else
+         return 0x00000000;
+}
+
+// Stubs: 
+uint32_t DfGetNumberOfDiesOnSocket (void)
+{
+  return 0; 
+}
+
+uint32_t
+DfGetHostBridgeSystemFabricID (
+  uint32_t Socket,
+  uint32_t Index
+  )
+{
+  return 771;
+}
+
+// Fakes: 
+const
+AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP *
+DfFindDeviceTypeEntryInMap (
+  FABRIC_DEVICE_TYPE  Type
+  )
+{
+    static const DEVICE_IDS myIds[1] = {0}; // Mock device IDs.
+    static const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP myMap[1] = 
+    {
+        {
+            Ios,       // Device type.
+            0,         // Device count.
+            myIds      // Associated device IDs...
+        }
+    };
+    return myMap; // Returns a mock device map for testing.
+}
+
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+    
+    if(strcmp(IterationName, "NoConditionBranch") == 0)
+    {
+        // Arrange
+        num = 1;
+        uint32_t Socket = 1;
+        uint32_t Index = 1; 
+        uint32_t result;
+
+        // Act 
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+        "Call DfXGetHostBridgeBusLimit");
+        result = DfXGetHostBridgeBusLimit(Socket, Index);
+        // Assert
+        if(result != 0xFF) 
+          UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+
+    }
+    else if(strcmp(IterationName, "ConditionBranch") == 0)
+    {
+        // Arrange
+        num = 0;
+        uint32_t Socket = 1;
+        uint32_t Index = 1; 
+        uint32_t result;
+        // Act 
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+        "Call DfXGetHostBridgeBusLimit");
+        result = DfXGetHostBridgeBusLimit(Socket, Index);
+        // Assert
+        if(result != 768) 
+          UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+
+    }
+    else
+    {
+        Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+            "Iteration '%s' is not implemented.", IterationName);
+        UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+
+    // if we run at any issue, The API is going to abort here.
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+        "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Starting point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  // Logging the start of the test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // Running test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetHostBridgeBL/GetHostBridgeBLUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetHostBridgeBL/GetHostBridgeBLUt.inf
@@ -1,0 +1,34 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  GetHostBridgeBLUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = GetHostBridgeBLUt
+  FILE_GUID      = F11DD60C-EA61-4DD4-9251-CCD1AE4A5A95
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  GetHostBridgeBLUt.c
+  ../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/DF/DfX/DfXBaseFabricTopology.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtSilServicesMockLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetHostBridgeBL/GetHostBridgeBLUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetHostBridgeBL/GetHostBridgeBLUt.json
@@ -1,0 +1,9 @@
+[   {
+    "Description": "This Iteration will execute DfXGetHostBridgeBusLimit and return default",
+    "Iteration": "NoConditionBranch"
+    },
+    {
+      "Description": "This Iteration will execute DfXGetHostBridgeBusLimit and enter condition branch",
+      "Iteration": "ConditionBranch"
+    }
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetPhysRootBN/GetPhysRootBNUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetPhysRootBN/GetPhysRootBNUt.c
@@ -1,0 +1,178 @@
+/**
+ * @file  GetPhysRootBNUt.c
+ * @brief Unit tests for DfXGetPhysRootBridgeNumber
+ *
+ * Iterations:
+ * - Default: Call DfXGetPhysRootBridgeNumber and execute general flow
+ *   
+ */
+
+
+#include <UtBaseLib.h>
+#include <UtLogLib.h>
+
+#include <OpenSIL\xUSL\DF\DfIp2Ip.h> // Can not recognize DfIp2Ip.h without relative path 
+#include "DfXBaseFabricTopology.h"
+
+// Mocks:
+static int num = 0; 
+uint32_t
+DfXFabricRegisterAccRead (
+  uint32_t Socket,
+  uint32_t Function,
+  uint32_t Offset,
+  uint32_t Instance
+  )
+{
+    if(num == 0)
+    {
+        return 0x00000303;
+    }
+    else
+         return 0x00000000;
+}
+
+// Stubs: 
+uint32_t DfGetNumberOfDiesOnSocket (void)
+{
+  return 0; 
+}
+
+uint32_t
+DfGetHostBridgeSystemFabricID (
+  uint32_t Socket,
+  uint32_t Index
+  )
+{
+  return 771;
+}
+
+// Fakes: 
+const
+AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP *
+DfFindDeviceTypeEntryInMap (
+  FABRIC_DEVICE_TYPE  Type
+  )
+{
+    static const DEVICE_IDS myIds[1] = {0}; // Mock device IDs.
+    static const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP myMap[1] = 
+    {
+        {
+            Ios,       // Device type.
+            0,         // Device count.
+            myIds      // Associated device IDs...
+        }
+    };
+    return myMap; // Returns a mock device map for testing.
+}
+
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+    
+    if(strcmp(IterationName, "Default") == 0)
+    {
+        // Arrange
+        uint32_t Index = 0; 
+        uint32_t result;
+
+        // Act 
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+        "Call DfXGetPhysRootBridgeNumber");
+        result = DfXGetPhysRootBridgeNumber(Index);
+        // Assert
+        if(result != -32) 
+          UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+
+    }
+    else
+    {
+        Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+            "Iteration '%s' is not implemented.", IterationName);
+        UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+
+    // if we run at any issue, The API is going to abort here.
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+        "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Starting point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  // Logging the start of the test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // Running test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetPhysRootBN/GetPhysRootBNUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetPhysRootBN/GetPhysRootBNUt.inf
@@ -1,0 +1,34 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  GetPhysRootBNUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = GetPhysRootBNUt
+  FILE_GUID      = F11DD60C-EA61-4DD4-9251-CCD1AE4A5A95
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  GetPhysRootBNUt.c
+  ../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/DF/DfX/DfXBaseFabricTopology.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtSilServicesMockLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetPhysRootBN/GetPhysRootBNUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/GetPhysRootBN/GetPhysRootBNUt.json
@@ -1,0 +1,5 @@
+[   {
+    "Description": "This Iteration will execute DfXGetPhysRootBridgeNumber",
+    "Iteration": "Default"
+    }
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfProcessors/NumberOfProcessorsUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfProcessors/NumberOfProcessorsUt.c
@@ -1,0 +1,171 @@
+/**
+ * @file NumberOfProcessorsUt.c
+ * @brief Unit tests for DfXGetNumberOfProcessorsPresent
+ *
+ * Iterations:
+ * -Default: Calls the DfXGetNumberOfProcessorsPresent function and stores the returned value. 
+ *           Verififes whether the returned value is as expected. 
+ *
+ */
+
+
+#include <UtBaseLib.h>
+#include <UtLogLib.h>
+
+// maybe it is not our mistake?
+#include <OpenSIL\xUSL\DF\DfIp2Ip.h> // Can not recognize DfIp2Ip.h without relative path 
+#include "DfXBaseFabricTopology.h"
+
+// Fakes:
+uint32_t
+DfXFabricRegisterAccRead (
+  uint32_t Socket,
+  uint32_t Function,
+  uint32_t Offset,
+  uint32_t Instance
+  )
+{
+    return 0; 
+}
+
+uint32_t DfGetNumberOfDiesOnSocket (void)
+{
+  return 1; 
+}
+
+uint32_t
+DfGetHostBridgeSystemFabricID (
+  uint32_t Socket,
+  uint32_t Index
+  )
+{
+  return 1;
+}
+
+// we can create a header file containing the fakes, mocks and stubs for a folder, and 
+// include the foldert
+const
+AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP *
+DfFindDeviceTypeEntryInMap (
+  FABRIC_DEVICE_TYPE  Type
+  )
+{
+    static const DEVICE_IDS myIds[1] = {0}; // Mock device IDs.
+    static const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP myMap[1] = 
+    {
+        {
+            Ios,       // Device type.
+            0,         // Device count.
+            myIds      // Associated device IDs...
+        }
+    };
+    return myMap; // Returns a mock device map for testing.
+}
+
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+    
+    if(strcmp(IterationName, "Default") == 0)
+    {
+        // Arrange
+        uint32_t result;
+        // Act 
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+        "Call DfXGetNumberOfProcessorsPresent");
+        result = DfXGetNumberOfProcessorsPresent();
+        // Assert
+        if(result != 1) 
+          UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+    else
+    {
+        Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+            "Iteration '%s' is not implemented.", IterationName);
+        UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+
+    // if we run at any issue, The API is going to abort here.
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+        "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Starting point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  // Logging the start of the test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // Running test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfProcessors/NumberOfProcessorsUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfProcessors/NumberOfProcessorsUt.inf
@@ -1,0 +1,34 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  NumberOfProcessorsUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = NumberOfProcessorsUt
+  FILE_GUID      = F11DD60C-EA61-4DD4-9251-CCD1AE4A5A95
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  NumberOfProcessorsUt.c
+  ../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/DF/DfX/DfXBaseFabricTopology.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtSilServicesMockLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfProcessors/NumberOfProcessorsUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfProcessors/NumberOfProcessorsUt.json
@@ -1,0 +1,6 @@
+[
+    {
+      "Description": "Call the DfXGetNumberOfProcessorsPresent function",
+      "Iteration": "Default"
+    }
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfRBOnD/NumberOfRBOnDUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfRBOnD/NumberOfRBOnDUt.c
@@ -1,0 +1,170 @@
+/**
+ * @file NumberOfRBOnDUt.c
+ * @brief Unit tests for DfXGetNumberOfRootBridgesOnDie
+ *
+ * Iterations:
+ * -Default: Calls the DfXGetNumberOfRootBridgesOnDie function and stores the returned value. 
+ *           Verififes whether the returned value is as expected. 
+ *
+ */
+
+
+#include <UtBaseLib.h>
+#include <UtLogLib.h>
+
+#include <OpenSIL\xUSL\DF\DfIp2Ip.h> // Can not recognize DfIp2Ip.h without relative path 
+#include "DfXBaseFabricTopology.h"
+
+// Fakes:
+uint32_t
+DfXFabricRegisterAccRead (
+  uint32_t Socket,
+  uint32_t Function,
+  uint32_t Offset,
+  uint32_t Instance
+  )
+{
+    return 1; 
+}
+
+uint32_t DfGetNumberOfDiesOnSocket (void)
+{
+  return 1; 
+}
+
+uint32_t
+DfGetHostBridgeSystemFabricID (
+  uint32_t Socket,
+  uint32_t Index
+  )
+{
+  return 1;
+}
+
+const
+AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP *
+DfFindDeviceTypeEntryInMap (
+  FABRIC_DEVICE_TYPE  Type
+  )
+{
+    static const DEVICE_IDS myIds[1] = {0}; // Mock device IDs.
+    static const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP myMap[1] = 
+    {
+        {
+            Ios,       // Device type.
+            0,         // Device count.
+            myIds      // Associated device IDs...
+        }
+    };
+    return myMap; // Returns a mock device map for testing.
+}
+
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+    
+    if(strcmp(IterationName, "Default") == 0)
+    {
+        // Arrange
+        uint32_t result;
+        uint32_t Socket = 1; 
+        // Act 
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+        "Call DfXGetNumberOfRootBridgesOnDie");
+        result = DfXGetNumberOfRootBridgesOnDie(Socket);
+        // Assert
+        if(result != 0) 
+          UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+
+    }
+    else
+    {
+        Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+            "Iteration '%s' is not implemented.", IterationName);
+        UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+
+    // if we run at any issue, The API is going to abort here.
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+        "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Starting point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  // Logging the start of the test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // Running test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfRBOnD/NumberOfRBOnDUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfRBOnD/NumberOfRBOnDUt.inf
@@ -1,0 +1,34 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  NumberOfRBOnDUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = NumberOfRBOnDUt
+  FILE_GUID      = F11DD60C-EA61-4DD4-9251-CCD1AE4A5A95
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  NumberOfRBOnDUt.c
+  ../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/DF/DfX/DfXBaseFabricTopology.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtSilServicesMockLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfRBOnD/NumberOfRBOnDUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfRBOnD/NumberOfRBOnDUt.json
@@ -1,0 +1,6 @@
+[
+    {
+      "Description": "Call the DfXGetNumberOfRootBridgesOnDie function",
+      "Iteration": "Default"
+    }
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfRBOnS/NumberOfRBOnSUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfRBOnS/NumberOfRBOnSUt.c
@@ -1,0 +1,170 @@
+/**
+ * @file NumberOfRBOnSUt.c
+ * @brief Unit tests for DfXGetNumberOfRootBridgesOnSocket
+ *
+ * Iterations:
+ * -Default: Calls the DfXGetNumberOfRootBridgesOnSocket function and stores the returned value. 
+ *           Verififes whether the returned value is as expected. 
+ *
+ */
+
+
+#include <UtBaseLib.h>
+#include <UtLogLib.h>
+
+#include <OpenSIL\xUSL\DF\DfIp2Ip.h> // Can not recognize DfIp2Ip.h without relative path 
+#include "DfXBaseFabricTopology.h"
+
+// Fakes:
+uint32_t
+DfXFabricRegisterAccRead (
+  uint32_t Socket,
+  uint32_t Function,
+  uint32_t Offset,
+  uint32_t Instance
+  )
+{
+    return 1; 
+}
+
+uint32_t DfGetNumberOfDiesOnSocket (void)
+{
+  return 1; 
+}
+
+uint32_t
+DfGetHostBridgeSystemFabricID (
+  uint32_t Socket,
+  uint32_t Index
+  )
+{
+  return 1;
+}
+
+const
+AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP *
+DfFindDeviceTypeEntryInMap (
+  FABRIC_DEVICE_TYPE  Type
+  )
+{
+    static const DEVICE_IDS myIds[1] = {0}; // Mock device IDs.
+    static const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP myMap[1] = 
+    {
+        {
+            Ios,       // Device type.
+            0,         // Device count.
+            myIds      // Associated device IDs...
+        }
+    };
+    return myMap; // Returns a mock device map for testing.
+}
+
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+    
+    if(strcmp(IterationName, "Default") == 0)
+    {
+        // Arrange
+        uint32_t result;
+        uint32_t Socket = 1; 
+        // Act 
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+        "Call DfXGetNumberOfRootBridgesOnSocket");
+        result = DfXGetNumberOfRootBridgesOnSocket(Socket);
+        // Assert
+        if(result != 0) 
+          UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+
+    }
+    else
+    {
+        Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+            "Iteration '%s' is not implemented.", IterationName);
+        UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+
+    // if we run at any issue, The API is going to abort here.
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+        "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Starting point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  // Logging the start of the test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // Running test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfRBOnS/NumberOfRBOnSUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfRBOnS/NumberOfRBOnSUt.inf
@@ -1,0 +1,34 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  NumberOfRBOnSUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = NumberOfRBOnSUt
+  FILE_GUID      = F11DD60C-EA61-4DD4-9251-CCD1AE4A5A95
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  NumberOfRBOnSUt.c
+  ../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/DF/DfX/DfXBaseFabricTopology.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtSilServicesMockLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfRBOnS/NumberOfRBOnSUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfRBOnS/NumberOfRBOnSUt.json
@@ -1,0 +1,6 @@
+[
+    {
+      "Description": "Call the DfXGetNumberOfRootBridgesOnSocket function",
+      "Iteration": "Default"
+    }
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfSystemDies/NumberOfSystemDiesUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfSystemDies/NumberOfSystemDiesUt.c
@@ -1,0 +1,168 @@
+/**
+ * @file NumberOfSystemDiesUt.c
+ * @brief Unit tests for DfXGetNumberOfSystemDies
+ *
+ * Iterations:
+ * -Default: Calls the DfXGetNumberOfSystemDies function and stores the returned value. 
+ *           Verififes whether the returned value is as expected. 
+ *
+ */
+
+
+#include <UtBaseLib.h>
+#include <UtLogLib.h>
+
+#include <OpenSIL\xUSL\DF\DfIp2Ip.h> // Can not recognize DfIp2Ip.h without relative path 
+#include "DfXBaseFabricTopology.h"
+
+// Fakes:
+uint32_t
+DfXFabricRegisterAccRead (
+  uint32_t Socket,
+  uint32_t Function,
+  uint32_t Offset,
+  uint32_t Instance
+  )
+{
+    return 1; 
+}
+
+uint32_t DfGetNumberOfDiesOnSocket (void)
+{
+  return 1; 
+}
+
+uint32_t
+DfGetHostBridgeSystemFabricID (
+  uint32_t Socket,
+  uint32_t Index
+  )
+{
+  return 1;
+}
+
+const
+AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP *
+DfFindDeviceTypeEntryInMap (
+  FABRIC_DEVICE_TYPE  Type
+  )
+{
+    static const DEVICE_IDS myIds[1] = {0}; // Mock device IDs.
+    static const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP myMap[1] = 
+    {
+        {
+            Ios,       // Device type.
+            0,         // Device count.
+            myIds      // Associated device IDs...
+        }
+    };
+    return myMap; // Returns a mock device map for testing.
+}
+
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+    
+    if(strcmp(IterationName, "Default") == 0)
+    {
+        // Arrange
+        uint32_t result;
+        // Act 
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+        "Call DfXGetNumberOfSystemDies");
+        result = DfXGetNumberOfSystemDies();
+        // Assert
+        if(result != 1) 
+          UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+    else
+    {
+        Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+            "Iteration '%s' is not implemented.", IterationName);
+        UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+
+    // if we run at any issue, The API is going to abort here.
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+        "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Starting point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  // Logging the start of the test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // Running test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfSystemDies/NumberOfSystemDiesUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfSystemDies/NumberOfSystemDiesUt.inf
@@ -1,0 +1,34 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  NumberOfSystemDiesUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = NumberOfSystemDiesUt
+  FILE_GUID      = F11DD60C-EA61-4DD4-9251-CCD1AE4A5A95
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  NumberOfSystemDiesUt.c
+  ../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/DF/DfX/DfXBaseFabricTopology.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtSilServicesMockLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfSystemDies/NumberOfSystemDiesUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfSystemDies/NumberOfSystemDiesUt.json
@@ -1,0 +1,6 @@
+[
+    {
+      "Description": "Call the DfXGetNumberOfSystemDies function",
+      "Iteration": "Default"
+    }
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfSystemRB/NumberOfSystemRBUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfSystemRB/NumberOfSystemRBUt.c
@@ -1,0 +1,168 @@
+/**
+ * @file NumberOfSystemRBUt.c
+ * @brief Unit tests for DfXGetNumberOfSystemRootBridges
+ *
+ * Iterations:
+ * -Default: Calls the DfXGetNumberOfSystemRootBridges function and stores the returned value. 
+ *           Verififes whether the returned value is as expected. 
+ *
+ */
+
+
+#include <UtBaseLib.h>
+#include <UtLogLib.h>
+
+#include <OpenSIL\xUSL\DF\DfIp2Ip.h> // Can not recognize DfIp2Ip.h without relative path 
+#include "DfXBaseFabricTopology.h"
+
+// Fakes:
+uint32_t
+DfXFabricRegisterAccRead (
+  uint32_t Socket,
+  uint32_t Function,
+  uint32_t Offset,
+  uint32_t Instance
+  )
+{
+    return 1; 
+}
+
+uint32_t DfGetNumberOfDiesOnSocket (void)
+{
+  return 1; 
+}
+
+uint32_t
+DfGetHostBridgeSystemFabricID (
+  uint32_t Socket,
+  uint32_t Index
+  )
+{
+  return 1;
+}
+
+const
+AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP *
+DfFindDeviceTypeEntryInMap (
+  FABRIC_DEVICE_TYPE  Type
+  )
+{
+    static const DEVICE_IDS myIds[1] = {0}; // Mock device IDs.
+    static const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP myMap[1] = 
+    {
+        {
+            Ios,       // Device type.
+            0,         // Device count.
+            myIds      // Associated device IDs...
+        }
+    };
+    return myMap; // Returns a mock device map for testing.
+}
+
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+    
+    if(strcmp(IterationName, "Default") == 0)
+    {
+        // Arrange
+        uint32_t result;
+        // Act 
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+        "Call DfXGetNumberOfSystemRootBridges");
+        result = DfXGetNumberOfSystemRootBridges();
+        // Assert
+        if(result != 0) 
+          UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+    else
+    {
+        Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+            "Iteration '%s' is not implemented.", IterationName);
+        UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+
+    // if we run at any issue, The API is going to abort here.
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+        "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Starting point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  // Logging the start of the test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // Running test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfSystemRB/NumberOfSystemRBUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfSystemRB/NumberOfSystemRBUt.inf
@@ -1,0 +1,34 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  NumberOfSystemRBUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = NumberOfSystemRBUt
+  FILE_GUID      = F11DD60C-EA61-4DD4-9251-CCD1AE4A5A95
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  NumberOfSystemRBUt.c
+  ../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/DF/DfX/DfXBaseFabricTopology.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtSilServicesMockLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfSystemRB/NumberOfSystemRBUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/NumberOfSystemRB/NumberOfSystemRBUt.json
@@ -1,0 +1,6 @@
+[
+    {
+      "Description": "Call the DfXGetNumberOfSystemRootBridges function",
+      "Iteration": "Default"
+    }
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/PieRasInit/PieRasInitUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/PieRasInit/PieRasInitUt.c
@@ -1,0 +1,203 @@
+/**
+ * @file PieRasInitUt.c
+ * @brief Unit tests for FabricPieRasInit
+ *
+ * Iterations:
+ * -AmdFabricWdtCntSel: Set xSimData's AmdFabricWdtCntSel to 0xFF
+ * -HwaStsLowValue:     Enter the DfXGetNumberOfProcessorsPresent and DfGetNumberOfDiesOnSocket loops 
+ *                      set HwaStsLow's Value with DfXFabricRegisterAccRead return values.     
+ * -CtrlInstance:       Enter the DfGlblCtrlInstanceIds loop 
+ */
+
+
+#include <UtBaseLib.h>
+#include <UtLogLib.h>
+#include <stdlib.h>
+#include "FabricPieRasInit.h"
+#include <DF/DfX/SilFabricRegistersDfX.h>
+
+HOST_DEBUG_SERVICE mHostDebugService;
+#define FABRIC_REG_ACC_BC    (0xFF)
+
+static bool NumberOfProcessors = true; 
+uint32_t DfXGetNumberOfProcessorsPresent (void){
+  if(NumberOfProcessors)
+    return 1;
+  else return 0; 
+};
+uint32_t DfGetNumberOfDiesOnSocket (void){
+  return 1;
+};
+
+static bool RegisterAccValue = true; 
+static int RegisterAccNum = -1; 
+uint32_t DfXFabricRegisterAccRead(
+  uint32_t Socket,
+  uint32_t Function, 
+  uint32_t Offset, 
+  uint32_t Instance){
+  if (RegisterAccValue && RegisterAccNum >= -1) {
+    RegisterAccNum++;   
+    return 1 << RegisterAccNum;
+  } else {
+    return 0x00000000; 
+  }
+}
+
+void
+DfXFabricRegisterAccWrite (
+  uint32_t Socket,
+  uint32_t Function,
+  uint32_t Offset,
+  uint32_t Instance,
+  uint32_t Value
+  ){
+    return;
+};
+
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+ {
+    AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+    const char* TestName        = UtGetTestName (Ut);
+    const char* IterationName   = UtGetTestIteration (Ut);
+  
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+      "%s (Iteration: %s) Test started.", TestName, IterationName);
+      
+      if(strcmp(IterationName, "AmdFabricWdtCntSel") == 0)
+      {
+          // Arrange
+          DFCLASS_INPUT_BLK* xSimData = (DFCLASS_INPUT_BLK*)malloc(sizeof(DFCLASS_INPUT_BLK));
+          memset(xSimData, 0, sizeof(DFCLASS_INPUT_BLK));
+          xSimData->AmdFabricWdtCntSel = 0xFF; 
+          RegisterAccValue = false;
+          NumberOfProcessors = false; 
+          // Act 
+          FabricPieRasInit(xSimData);
+          Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+          "Call FabricPieRasInit");
+          // Assert  
+      }
+      else if(strcmp(IterationName, "HwaStsLowValue") == 0)
+      {
+          // Arrange
+          DFCLASS_INPUT_BLK* xSimData = (DFCLASS_INPUT_BLK*)malloc(sizeof(DFCLASS_INPUT_BLK));
+          memset(xSimData, 0, sizeof(DFCLASS_INPUT_BLK));
+
+          uint32_t *ids = (uint32_t *)malloc(2 * sizeof(uint32_t));
+          ids[0] = 0xFFFFFFFF;
+          xSimData->DfGlblCtrlInstanceIds = ids;
+
+          // Act 
+          FabricPieRasInit(xSimData);
+          Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+          "Call FabricPieRasInit");
+          // Assert  
+      }
+      else if(strcmp(IterationName, "CtrlInstance") == 0)
+      {
+          // Arrange
+          DFCLASS_INPUT_BLK* xSimData = (DFCLASS_INPUT_BLK*)malloc(sizeof(DFCLASS_INPUT_BLK));
+          memset(xSimData, 0, sizeof(DFCLASS_INPUT_BLK));
+
+          uint32_t *ids = (uint32_t *)malloc(2 * sizeof(uint32_t));
+          ids[0] = 1;
+          ids[1] = 0xFFFFFFFF;
+          xSimData->DfGlblCtrlInstanceIds = ids;
+
+          RegisterAccValue = true;
+          RegisterAccNum = -10; 
+
+          // Act 
+          FabricPieRasInit(xSimData);
+          Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+          "Call FabricPieRasInit");
+          // Assert  
+      }
+      else
+      {
+          Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+              "Iteration '%s' is not implemented.", IterationName);
+          UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+      }
+  
+      // if we run at any issue, The API is going to abort here.
+      UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+  
+      Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+          "%s (Iteration: %s) Test ended.", TestName, IterationName);
+ }
+ 
+ AMD_UNIT_TEST_STATUS
+ EFIAPI
+ TestCleanUp (
+   IN AMD_UNIT_TEST_CONTEXT Context
+   )
+ {
+   return AMD_UNIT_TEST_PASSED;
+ }
+ 
+ /**
+  * main
+  * @brief      Starting point for Execution
+  *
+  * @details    This routine:
+  *              - Handles the command line arguments.
+  *              - Declares the unit test framework.
+  *              - Run the tests.
+  *              - Deallocate the Unit test framework.
+  *
+  * @param      argc                     Argument count
+  * @param      *argv[]                  Argument vector
+  *
+  * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+  * @retval     NON-ZERO                 Error occurs
+  */
+ int
+ main (
+   int   argc,
+   char  *argv[]
+   )
+ {
+   AMD_UNIT_TEST_STATUS Status;
+   AMD_UNIT_TEST_FRAMEWORK Ut;
+ 
+   // Initializing the UnitTest framework
+   Status = UtInitFromArgs (
+     &Ut,
+     argc,
+     argv
+   );
+   if (Status != AMD_UNIT_TEST_PASSED) {
+     return Status;
+   }
+ 
+   // Logging the start of the test.
+   Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+     "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+ 
+   // Running test.
+   Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+   UtRunTest (&Ut);
+ 
+   // Freeing up all framework related allocated memories
+   Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+   UtDeinit (&Ut);
+ 
+   return AMD_UNIT_TEST_PASSED;
+ }
+ 

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/PieRasInit/PieRasInitUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/PieRasInit/PieRasInitUt.inf
@@ -1,0 +1,34 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  PieRasInitUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = PieRasInitUt
+  FILE_GUID      = F11DD60C-EA61-4DD4-9251-CCD1AE4A5A95
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  PieRasInitUt.c
+  ../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/DF/DfX/FabricPieRasInit/FabricPieRasInit.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtSilServicesMockLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/PieRasInit/PieRasInitUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/PieRasInit/PieRasInitUt.json
@@ -1,0 +1,14 @@
+[
+    {
+      "Description": "Set xSimData's AmdFabricWdtCntSel",
+      "Iteration": "AmdFabricWdtCntSel"
+    }, 
+    {
+      "Description": "Enter the DfXGetNumberOfProcessorsPresent and DfGetNumberOfDiesOnSocket loops",
+      "Iteration": "HwaStsLowValue"
+    }, 
+    {
+      "Description": "Enter the DfGlblCtrlInstanceIds loop",
+      "Iteration": "CtrlInstance"
+    }
+  ]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/RootBridgeInfo/RootBridgeInfoUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/RootBridgeInfo/RootBridgeInfoUt.c
@@ -1,0 +1,348 @@
+/**
+ * @file RootBridgeInfoUt.c
+ * @brief Unit tests for the DfGetRootBridgeInfo function.
+ *
+ * @details
+ * This file contains unit tests for the following function:
+ * 
+ * SIL_STATUS DfGetRootBridgeInfo(
+ *     uint32_t Socket,
+ *     uint32_t Die,
+ *     uint32_t Index,
+ *     uint32_t *SystemFabricID,
+ *     uint32_t *BusNumberBase,
+ *     uint32_t *BusNumberLimit,
+ *     uint32_t *PhysicalRootBridgeNumber,
+ *     bool *HasFchDevice,
+ *     bool *HasSystemMgmtUnit
+ * );
+ *
+ * The tests iterate through all possible branches for each argument
+ * to validate proper functionality.
+ */
+
+#include <stdlib.h>                       
+
+#include <UtBaseLib.h>
+#include <UtLogLib.h>
+
+#include <DfCmn2Rev.h>                    
+#include <Sil-api.h>
+#include <SilBaseFabricTopologyLib.h>
+#include <SilCommon.h>
+#include <xSIM-api.h>
+#include <xSIM.h>
+
+#include <Library/UtSilServicesMockLib.h> 
+
+#include "BaseFabricTopologyCmn.h"        
+
+// Dependency:
+// This variable holds the host debug service instance.
+HOST_DEBUG_SERVICE mHostDebugService = NULL;
+
+// API Table Functions:
+// These functions simulate basic functionality for testing purposes.
+uint32_t My_DfGetNumberOfProcessorsPresent(void)
+{
+    return 10; 
+}
+
+uint32_t My_DfGetNumberOfRootBridgesOnDie(uint32_t Socket)
+{
+    return 10; 
+}
+
+uint32_t My_DfGetHostBridgeBusBase(uint32_t Socket, uint32_t Index)
+{
+    return 0; 
+}
+
+uint32_t My_DfGetHostBridgeBusLimit(uint32_t Socket, uint32_t Index)
+{
+    return 0; 
+}
+
+uint32_t My_DfGetPhysRootBridgeNumber(uint32_t Index)
+{
+    return 0; 
+}
+
+// Non-Tested Functions (API Table Functions):
+// These functions provide mock implementations for non-tested APIs.
+const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP* My_DfGetDeviceMapOnDie(void)
+{
+    static const DEVICE_IDS myIds[1] = {0}; // Mock device IDs.
+    static const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP myMap[1] = {
+        {
+            Ios,       // Device type.
+            0,         // Device count.
+            myIds      // Associated device IDs.
+        }
+    };
+    return myMap; // Returns a mock device map for testing.
+}
+
+uint32_t My_DfGetDieSystemOffset(uint32_t Socket)
+{
+    return 0; // Returns a fixed system offset for the specified socket.
+}
+
+const COMPONENT_LOCATION* My_DfFindComponentLocationMap(uint32_t *Count, uint32_t *PhysIos0FabricId)
+{
+    static const COMPONENT_LOCATION myComponents[1] = {
+        0, 0, 0, PrimarySmu // Mock component location data.
+    };
+    return myComponents; // Returns a mock component location map.
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+
+    // Input values for DfGetRootBridgeInfo
+    uint32_t Socket = 0;
+    uint32_t Die = 0;
+    uint32_t Index = 0;
+    uint32_t *SystemFabricID = NULL;
+    uint32_t *BusNumberBase = NULL;
+    uint32_t *BusNumberLimit = NULL;
+    uint32_t *PhysicalRootBridgeNumber = NULL;
+    bool *HasFchDevice = NULL;
+    bool *HasSystemMgmtUnit = NULL; 
+    // The API table
+    DF_COMMON_2_REV_XFER_BLOCK passedTable = {NULL};            
+    // Called API table functions in the DfGetRootBridgeInfo
+    passedTable.DfGetNumberOfProcessorsPresent = My_DfGetNumberOfProcessorsPresent;  
+    passedTable.DfGetNumberOfRootBridgesOnDie = My_DfGetNumberOfRootBridgesOnDie;
+    passedTable.DfGetHostBridgeBusBase = My_DfGetHostBridgeBusBase; 
+    passedTable.DfGetHostBridgeBusLimit = My_DfGetHostBridgeBusLimit; 
+    passedTable.DfGetPhysRootBridgeNumber = My_DfGetPhysRootBridgeNumber;     
+    passedTable.DfGetDeviceMapOnDie = My_DfGetDeviceMapOnDie; 
+    passedTable.DfGetDieSystemOffset = My_DfGetDieSystemOffset;
+    passedTable.DfFindComponentLocationMap = My_DfFindComponentLocationMap;
+    if(strcmp(IterationName, "Socket") == 0)
+    {
+        // Arrange
+        SIL_STATUS Status = SilPass;                                // status
+        Socket = 100;                                               // input - Socket branch 
+        MockSilGetCommon2RevXferTableOnce(&passedTable, Status);    // mock with proper table and status
+        // Act 
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+        "Call DfGetRootBridgeInfo and enter Socket branch");
+        SIL_STATUS returnedStatus = DfGetRootBridgeInfo (Socket, Die, Index, SystemFabricID, BusNumberBase, 
+                                                        BusNumberLimit, PhysicalRootBridgeNumber, HasFchDevice, 
+                                                        HasSystemMgmtUnit);
+        // Assert
+        if(SilInvalidParameter != returnedStatus)
+            UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+    else if(strcmp(IterationName, "Die") == 0)
+    {
+        // Arrange
+        SIL_STATUS Status = SilPass;                                // status
+        Die = 100;                                                  // input - Die branch 
+        MockSilGetCommon2RevXferTableOnce(&passedTable, Status);    // mock with proper table and status
+        // Act
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+            "Call DfGetRootBridgeInfo and enter Die branch");
+        SIL_STATUS returnedStatus = DfGetRootBridgeInfo (Socket, Die, Index, SystemFabricID, BusNumberBase, 
+                                                        BusNumberLimit, PhysicalRootBridgeNumber, HasFchDevice, 
+                                                        HasSystemMgmtUnit);
+        // Assert
+        if(SilInvalidParameter != returnedStatus)
+            UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+    else if(strcmp(IterationName, "Index") == 0)
+    {
+        // Arrange
+        SIL_STATUS Status = SilPass;                                // status
+        Index = 100;                                                // input - Die branch 
+        MockSilGetCommon2RevXferTableOnce(&passedTable, Status);    // mock with proper table and status
+        // Act
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+            "Call DfGetRootBridgeInfo and enter Index branch");
+        SIL_STATUS returnedStatus = DfGetRootBridgeInfo (Socket, Die, Index, SystemFabricID, BusNumberBase, 
+                                                        BusNumberLimit, PhysicalRootBridgeNumber, HasFchDevice, 
+                                                        HasSystemMgmtUnit);
+        // Assert
+        if(SilInvalidParameter != returnedStatus)
+            UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }    
+    else if(strcmp(IterationName, "SystemFabricID") == 0)
+    {
+        // Arrange
+        SIL_STATUS Status = SilPass;                                     // status
+        SystemFabricID = malloc(sizeof(uint32_t));                       // input - SystemFabricID branch 
+        *SystemFabricID = 1;
+        MockSilGetCommon2RevXferTableManyTimes(&passedTable, Status, 3); // mock with proper table and status
+        // Act
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+            "Call DfGetRootBridgeInfo and enter SystemFabricID branch");
+        SIL_STATUS returnedStatus = DfGetRootBridgeInfo (Socket, Die, Index, SystemFabricID, BusNumberBase, 
+                                                        BusNumberLimit, PhysicalRootBridgeNumber, HasFchDevice, 
+                                                        HasSystemMgmtUnit);
+        // Assert
+        if(SilPass != returnedStatus)
+            UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }  
+    else if(strcmp(IterationName, "BusNumberLimit") == 0)
+    {
+        // Arrange
+        SIL_STATUS Status = SilPass;                                // status
+        BusNumberLimit = malloc(sizeof(uint32_t));          // input - SystemFabricID branch 
+        *BusNumberLimit = 1;
+        MockSilGetCommon2RevXferTableOnce(&passedTable, Status);    // mock with proper table and status
+        // Act
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+            "Call DfGetRootBridgeInfo and enter BusNumberLimit branch");
+        SIL_STATUS returnedStatus = DfGetRootBridgeInfo (Socket, Die, Index, SystemFabricID, BusNumberBase, 
+                                                        BusNumberLimit, PhysicalRootBridgeNumber, HasFchDevice, 
+                                                        HasSystemMgmtUnit);
+        // Assert
+        if(SilPass != returnedStatus)
+            UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }   
+    else if(strcmp(IterationName, "PhysicalRootBridgeNumber") == 0)
+    {
+        // Arrange
+        SIL_STATUS Status = SilPass;                                // status
+        PhysicalRootBridgeNumber = malloc(sizeof(uint32_t));          // input - SystemFabricID branch 
+        *PhysicalRootBridgeNumber = 1;
+        MockSilGetCommon2RevXferTableOnce(&passedTable, Status);    // mock with proper table and status
+        // Act
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+            "Call DfGetRootBridgeInfo and enter PhysicalRootBridgeNumber branch");
+        SIL_STATUS returnedStatus = DfGetRootBridgeInfo (Socket, Die, Index, SystemFabricID, BusNumberBase, 
+                                                        BusNumberLimit, PhysicalRootBridgeNumber, HasFchDevice, 
+                                                        HasSystemMgmtUnit);
+        // Assert
+        if(SilPass != returnedStatus)
+            UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }   
+    else if(strcmp(IterationName, "HasFchDevice") == 0)
+    {
+        // Arrange
+        SIL_STATUS Status = SilPass;                                // status
+        HasFchDevice = malloc(sizeof(bool));                        // input - SystemFabricID branch 
+        *HasFchDevice = true;
+        Die = 0; // 
+        MockSilGetCommon2RevXferTableManyTimes(&passedTable, Status, 3); // mock with proper table and status
+        // Act
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+            "Call DfGetRootBridgeInfo and enter HasFchDevice branch");
+        SIL_STATUS returnedStatus = DfGetRootBridgeInfo (Socket, Die, Index, SystemFabricID, BusNumberBase, 
+                                                        BusNumberLimit, PhysicalRootBridgeNumber, HasFchDevice, 
+                                                        HasSystemMgmtUnit);
+        // Assert
+        if(SilPass != returnedStatus)
+            UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }   
+    else if(strcmp(IterationName, "HasSystemMgmtUnit") == 0)
+    {
+        // Arrange
+        SIL_STATUS Status = SilPass;                                // status
+        HasSystemMgmtUnit = malloc(sizeof(bool));                        // input - SystemFabricID branch 
+        *HasSystemMgmtUnit = true;
+        Die = 0; // 
+        MockSilGetCommon2RevXferTableManyTimes(&passedTable, Status, 3); // mock with proper table and status
+        // Act
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+            "Call DfGetRootBridgeInfo and enter HasSystemMgmtUnit branch");
+        SIL_STATUS returnedStatus = DfGetRootBridgeInfo (Socket, Die, Index, SystemFabricID, BusNumberBase, 
+                                                        BusNumberLimit, PhysicalRootBridgeNumber, HasFchDevice, 
+                                                        HasSystemMgmtUnit);
+        // Assert
+        if(SilPass != returnedStatus)
+            UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }        
+    else
+    {
+        Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+            "Iteration '%s' is not implemented.", IterationName);
+        UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+
+    // if we run at any issue, The API is going to abort here.
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+        "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Starting point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  // Logging the start of the test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // Running test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/RootBridgeInfo/RootBridgeInfoUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/RootBridgeInfo/RootBridgeInfoUt.inf
@@ -1,0 +1,34 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  RootBridgeInfoUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = RootBridgeInfoUt
+  FILE_GUID      = 58C89109-EE13-4C3D-9868-25F15647A6C5
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  RootBridgeInfoUt.c
+  ../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/DF/Common/BaseFabricTopologyCmn.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtSilServicesMockLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/RootBridgeInfo/RootBridgeInfoUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/RootBridgeInfo/RootBridgeInfoUt.json
@@ -1,0 +1,34 @@
+[
+    {
+      "Description": "This Iteration will execute DfGetRootBridgeInfo and enter Socket branch",
+      "Iteration": "Socket"
+    },
+    {
+      "Description": "This Iteration will execute DfGetRootBridgeInfo and enter Die branch",
+      "Iteration": "Die"
+    },
+    {
+      "Description": "This Iteration will execute DfGetRootBridgeInfo and enter Index branch",
+      "Iteration": "Index"
+    },
+    {
+      "Description": "This Iteration will execute DfGetRootBridgeInfo and enter SystemFabricID branch",
+      "Iteration": "SystemFabricID"
+    },
+    {
+      "Description": "This Iteration will execute DfGetRootBridgeInfo and enter BusNumberLimit branch",
+      "Iteration": "BusNumberLimit"
+    },
+    {
+      "Description": "This Iteration will execute DfGetRootBridgeInfo and enter PhysicalRootBridgeNumber branch",
+      "Iteration": "PhysicalRootBridgeNumber"
+    },
+    {
+      "Description": "This Iteration will execute DfGetRootBridgeInfo and enter HasFchDevice branch",
+      "Iteration": "HasFchDevice"
+    },
+    {
+      "Description": "This Iteration will execute DfGetRootBridgeInfo and enter HasSystemMgmtUnit branch",
+      "Iteration": "HasSystemMgmtUnit"
+    }
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/TypeEntryInMap/TypeEntryInMapUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/TypeEntryInMap/TypeEntryInMapUt.c
@@ -4,9 +4,12 @@
  *
  * Iterations:
  *
- * -Default: Executes 
- *  const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP* DfFindDeviceTypeEntryInMap(FABRIC_DEVICE_TYPE)
+ *   - TypeMatch:    Executes DfFindDeviceTypeEntryInMap and passes the Type 
+ *                   that matches the DeviceMap Type returned from the API table (XferTable).
+ *   - TypeMismatch: Executes DfFindDeviceTypeEntryInMap and passes the Type 
+ *                   that mismatches the DeviceMap Type returned from the API table (XferTable).
  */
+
 
 #include <UtBaseLib.h>
 #include <UtLogLib.h>
@@ -14,18 +17,20 @@
 #include <SilBaseFabricTopologyLib.h>
 #include <DfCmn2Rev.h>
 #include <xSIM.h>
+#include <xSIM-api.h>
 #include <Sil-api.h>
 #include <SilCommon.h>
-#include "BaseFabricTopologyCmn.h"
-
-#include <xSIM-api.h>
 
 #include <Library/UtSilServicesMockLib.h>
 
+#include "BaseFabricTopologyCmn.h"
+
 // Dependency:
+// This variable holds the host debug service instance.
 HOST_DEBUG_SERVICE mHostDebugService = NULL;
 
-// API table function:
+// API Table Functions:
+// These functions simulate basic functionality for testing purposes.
 const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP* My_DfGetDeviceMapOnDie(void)
 {
     static const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP myMap[3] = {0}; 
@@ -61,10 +66,10 @@ TestBody (
         SIL_STATUS Status = SilPass;                                // status
         FABRIC_DEVICE_TYPE passedType = {0};                        // input - type
 
-        DF_COMMON_2_REV_XFER_BLOCK passedTable = {NULL};            // table
-        passedTable.DfGetDeviceMapOnDie = My_DfGetDeviceMapOnDie;   // called function in the table
+        DF_COMMON_2_REV_XFER_BLOCK passedTable = {NULL};            // API table
+        passedTable.DfGetDeviceMapOnDie = My_DfGetDeviceMapOnDie;   // called function in the API table
 
-        MockSilGetCommon2RevXferTableOnce(&passedTable, Status);    // mock with proper table and status
+        MockSilGetCommon2RevXferTableOnce(&passedTable, Status);    // mock with proper API table and status
         // Act 
         Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
         "Call DfFindDeviceTypeEntryInMap with the matching Type");
@@ -79,16 +84,16 @@ TestBody (
         SIL_STATUS Status = SilPass;                                // status
         FABRIC_DEVICE_TYPE passedType = {1};                        // input - type
 
-        DF_COMMON_2_REV_XFER_BLOCK passedTable = {NULL};            // table
-        passedTable.DfGetDeviceMapOnDie = My_DfGetDeviceMapOnDie;   // called function in the table
+        DF_COMMON_2_REV_XFER_BLOCK passedTable = {NULL};            // API table
+        passedTable.DfGetDeviceMapOnDie = My_DfGetDeviceMapOnDie;   // called function in the API table
 
-        MockSilGetCommon2RevXferTableOnce(&passedTable, Status);    // mock with proper table and status
+        MockSilGetCommon2RevXferTableOnce(&passedTable, Status);    // mock with proper API table and status
         // Act
         Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
             "Call DfFindDeviceTypeEntryInMap with the mismsatching Type");
         const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP * returnedMap = DfFindDeviceTypeEntryInMap (passedType);
         // Assert
-        if(returnedMap->Type == passedType) 
+        if(returnedMap) // should be null 
           UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
     }
     else

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/TypeEntryInMap/TypeEntryInMapUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/TypeEntryInMap/TypeEntryInMapUt.c
@@ -1,0 +1,165 @@
+/**
+ * @file TypeEntryInMapUt.c
+ * @brief Unit tests for DfFindDeviceTypeEntryInMap
+ *
+ * Iterations:
+ *
+ * -Default: Executes 
+ *  const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP* DfFindDeviceTypeEntryInMap(FABRIC_DEVICE_TYPE)
+ */
+
+#include <UtBaseLib.h>
+#include <UtLogLib.h>
+
+#include <SilBaseFabricTopologyLib.h>
+#include <DfCmn2Rev.h>
+#include <xSIM.h>
+#include <Sil-api.h>
+#include <SilCommon.h>
+#include "BaseFabricTopologyCmn.h"
+
+#include <xSIM-api.h>
+
+#include <Library/UtSilServicesMockLib.h>
+
+// Dependency:
+HOST_DEBUG_SERVICE mHostDebugService = NULL;
+
+// API table function:
+const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP* My_DfGetDeviceMapOnDie(void)
+{
+    static const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP myMap[3] = {0}; 
+    return myMap; 
+}
+
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+    
+    if(strcmp(IterationName, "TypeMatch") == 0)
+    {
+        // Arrange
+        SIL_STATUS Status = SilPass;                                // status
+        FABRIC_DEVICE_TYPE passedType = {0};                        // input - type
+
+        DF_COMMON_2_REV_XFER_BLOCK passedTable = {NULL};            // table
+        passedTable.DfGetDeviceMapOnDie = My_DfGetDeviceMapOnDie;   // called function in the table
+
+        MockSilGetCommon2RevXferTableOnce(&passedTable, Status);    // mock with proper table and status
+        // Act 
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+        "Call DfFindDeviceTypeEntryInMap with the matching Type");
+        const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP * returnedMap = DfFindDeviceTypeEntryInMap (passedType);
+        // Assert
+        if(returnedMap->Type != passedType) 
+          UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+    else if(strcmp(IterationName, "TypeMismatch") == 0)
+    {
+        // Arrange
+        SIL_STATUS Status = SilPass;                                // status
+        FABRIC_DEVICE_TYPE passedType = {1};                        // input - type
+
+        DF_COMMON_2_REV_XFER_BLOCK passedTable = {NULL};            // table
+        passedTable.DfGetDeviceMapOnDie = My_DfGetDeviceMapOnDie;   // called function in the table
+
+        MockSilGetCommon2RevXferTableOnce(&passedTable, Status);    // mock with proper table and status
+        // Act
+        Ut->Log(AMD_UNIT_TEST_LOG_DEBUG, __FUNCTION__, __LINE__, 
+            "Call DfFindDeviceTypeEntryInMap with the mismsatching Type");
+        const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP * returnedMap = DfFindDeviceTypeEntryInMap (passedType);
+        // Assert
+        if(returnedMap->Type == passedType) 
+          UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+    else
+    {
+        Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+            "Iteration '%s' is not implemented.", IterationName);
+        UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+
+    // if we run at any issue, The API is going to abort here.
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+        "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Starting point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  // Logging the start of the test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // Running test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/TypeEntryInMap/TypeEntryInMapUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/TypeEntryInMap/TypeEntryInMapUt.inf
@@ -1,0 +1,34 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  TypeEntryInMapUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = TypeEntryInMapUt
+  FILE_GUID      = F11DD60C-EA61-4DD4-9251-CCD1AE4A5A95
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  TypeEntryInMapUt.c
+  ../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/DF/Common/BaseFabricTopologyCmn.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtSilServicesMockLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/TypeEntryInMap/TypeEntryInMapUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/DF/TypeEntryInMap/TypeEntryInMapUt.json
@@ -1,0 +1,10 @@
+[
+    {
+      "Description": "This Iteration will execute DfFindDeviceTypeEntryInMap by passing a Type that will match one of the AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP's Types",
+      "Iteration": "TypeMatch"
+    }, 
+    {
+      "Description": "This Iteration will execute DfFindDeviceTypeEntryInMap by passing a Type that will not match any of the AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP's Types",
+      "Iteration": "TypeMismatch"
+    }
+  ]


### PR DESCRIPTION
**CcxEnableSmeeUt:** 
This unit test verifies CcxEnableSmee function with 2 iterations, which pass true and false SmeeEnable arguments into it. 

**CcxSetCacWeightsUt:**
This unit test verifies CcxSetCacWeights function with 2 iterations, which mock true and false return values for xUslIsComputeUnitPrimary function, and pass valid sized CacWeights array. 

**CcxInitializeCpUt:**
This unit test verifies CcxInitializeCp with 2 iterations, which pass 1 and 0 CpbEnable arguments into it. 

**DfFindDeviceTypeEntryInMap**
This unit test verifies DfFindDeviceTypeEntryInMap with 2 iterations, where the Type argument either matches or mismatches the DeviceMap Type returned from the API table (XferTable). 

**DfGetRootBridgeInfo**
This unit test verifies DfGetRootBridgeInfo with 9 iterations, each corresponding to a parameter in the list and entering the respective if branches: Socket, Die, Index, SystemFabricID, BusNumberBase, BusNumberLimit, PhysicalRootBridgeNumber, HasFchDevice, and HasSystemMgmtUnit. 