### PR TITLE
Add new units tests - Andy

### DIFF
--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dsc.inc
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dsc.inc
@@ -23,7 +23,7 @@
   UtxSIMMockLib|$(OPENSIL_UTPATH)/Mocks/UtxSIMMockLib/UtxSIMMockLib.inf
   UtSilServicesMockLib|$(OPENSIL_UTPATH)/Mocks/UtSilServicesMockLib/UtSilServicesMockLib.inf
   UtSmnAccessStubLib|$(OPENSIL_UTPATH)/Stubs/UtSmnAccessStubLib/UtSmnAccessStubLib.inf
-  UtxUsMockLib|$(OPENSIL_UTPATH)/Mocks/UtxUsMockLib/UtxUsMockLib.inf
+  UtCpuOpsMockLib|$(OPENSIL_UTPATH)/Mocks/UtCpuOpsMockLib/UtCpuOpsMockLib.inf
 
 [BuildOptions]
   GCC:*_*_*_CC_FLAGS     = -D UNIT_TEST_RUN

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dsc.inc
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dsc.inc
@@ -23,6 +23,7 @@
   UtxSIMMockLib|$(OPENSIL_UTPATH)/Mocks/UtxSIMMockLib/UtxSIMMockLib.inf
   UtSilServicesMockLib|$(OPENSIL_UTPATH)/Mocks/UtSilServicesMockLib/UtSilServicesMockLib.inf
   UtSmnAccessStubLib|$(OPENSIL_UTPATH)/Stubs/UtSmnAccessStubLib/UtSmnAccessStubLib.inf
+  UtxUsMockLib|$(OPENSIL_UTPATH)/Mocks/UtxUsMockLib/UtxUsMockLib.inf
 
 [BuildOptions]
   GCC:*_*_*_CC_FLAGS     = -D UNIT_TEST_RUN

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkgGn.dsc.inc
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkgGn.dsc.inc
@@ -28,3 +28,7 @@
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetProcessorInfoUt/DfGetProcessorInfoUt.inf
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetDieInfoUt/DfGetDieInfoUt.inf
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetSystemInfoUt/DfGetSystemInfoUt.inf
+
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindPcieCoreDescUt/FindPcieCoreDescUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindLastPciePortOnPrevPcieCUt/FindLastPciePortOnPrevPcieCUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindLastPciePortOfThisPcieCUt/FindLastPciePortOfThisPcieCUt.inf

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkgGn.dsc.inc
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkgGn.dsc.inc
@@ -27,3 +27,4 @@
 
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetProcessorInfoUt/DfGetProcessorInfoUt.inf
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetDieInfoUt/DfGetDieInfoUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetSystemInfoUt/DfGetSystemInfoUt.inf

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkgGn.dsc.inc
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkgGn.dsc.inc
@@ -24,3 +24,6 @@
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxEnableSmeeUt/CcxEnableSmeeUt.inf
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxSetCacWeightsUt/CcxSetCacWeightsUt.inf
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxGetCacWeightsUt/CcxGetCacWeightsUt.inf
+
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetProcessorInfoUt/DfGetProcessorInfoUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetDieInfoUt/DfGetDieInfoUt.inf

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkgGn.dsc.inc
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkgGn.dsc.inc
@@ -36,3 +36,6 @@
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/PcieConfigAttachDescriptorsUt/PcieConfigAttachDescriptorsUt.inf
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindPrevPcieCoreUt/FindPrevPcieCoreUt.inf
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/IsSteppingAxUt/IsSteppingAxUt.inf
+
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/PcieEnumerateAndHarvestWrUt/PcieEnumerateAndHarvestWrUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/InitNbioConfigDataUt/InitNbioConfigDataUt.inf

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkgGn.dsc.inc
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkgGn.dsc.inc
@@ -32,3 +32,7 @@
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindPcieCoreDescUt/FindPcieCoreDescUt.inf
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindLastPciePortOnPrevPcieCUt/FindLastPciePortOnPrevPcieCUt.inf
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindLastPciePortOfThisPcieCUt/FindLastPciePortOfThisPcieCUt.inf
+
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/PcieConfigAttachDescriptorsUt/PcieConfigAttachDescriptorsUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindPrevPcieCoreUt/FindPrevPcieCoreUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/IsSteppingAxUt/IsSteppingAxUt.inf

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkgGn.dsc.inc
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkgGn.dsc.inc
@@ -20,3 +20,7 @@
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Fch/FchAb/FchInitResetAbUt/FchInitResetAbUt.inf
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Fch/FchAb/FchAbSetInputBlkUt/FchAbSetInputBlkUt.inf
   AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Fch/FchAb/FchInitEnvAbUt/FchInitEnvAbUt.inf
+
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxEnableSmeeUt/CcxEnableSmeeUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxSetCacWeightsUt/CcxSetCacWeightsUt.inf
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxGetCacWeightsUt/CcxGetCacWeightsUt.inf

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Include/Library/UtCpuOpsMockLib.h
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Include/Library/UtCpuOpsMockLib.h
@@ -1,8 +1,8 @@
 /* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
 // SPDX-License-Identifier: MIT
 /**
- * @file UtxUsMockLib.h
- * @brief This header contains definitions used by UtxUsMockLib
+ * @file UtCpuOpsMockLib.h
+ * @brief This header contains definitions used by UtCpuOpsMockLib
  *
  */
 #pragma once

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Include/Library/UtSilServicesMockLib.h
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Include/Library/UtSilServicesMockLib.h
@@ -14,6 +14,13 @@ MockSilGetCommon2RevXferTableOnce (
   );
 
 void
+MockSilGetCommon2RevXferTableManyTimes (
+  void            *ExpectedXferTable,
+  SIL_STATUS      ExpectedSilStatus,
+  uint32_t        Count 
+  );
+
+void
 MockSilInitCommon2RevXferTableOnce (
   void            *ExpectedXferTable,
   SIL_STATUS      ExpectedSilStatus

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Include/Library/UtxUsMockLib.h
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Include/Library/UtxUsMockLib.h
@@ -1,0 +1,19 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file UtxUsMockLib.h
+ * @brief This header contains definitions used by UtxUsMockLib
+ *
+ */
+#pragma once
+
+#include <Uefi.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <Io.h>
+
+void MockxUslIsComputeUnitPrimary(
+    bool ExpectedValue
+    );

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Library/Mocks/UtCpuOpsMockLib/UtCpuOpsMockLib.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Library/Mocks/UtCpuOpsMockLib/UtCpuOpsMockLib.c
@@ -1,8 +1,8 @@
 /* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
 // SPDX-License-Identifier: MIT
 /**
- * @file  UtIoMockLib.c
- * @brief xUs Mock Library
+ * @file  UtCpuOpsMockLib.c
+ * @brief CPU Operation Mock Library
  *
  */
 

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Library/Mocks/UtCpuOpsMockLib/UtCpuOpsMockLib.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Library/Mocks/UtCpuOpsMockLib/UtCpuOpsMockLib.inf
@@ -1,20 +1,20 @@
 # Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 #
-# @file  UtxUsMockLib.inf
+# @file  UtCpuOpsMockLib.inf
 # @brief
 #
 
 [Defines]
   INF_VERSION                    = 0x00010006
-  BASE_NAME                      = UtxUsMockLib
+  BASE_NAME                      = UtCpuOpsMockLib
   FILE_GUID                      = ab32c5b9-1d9a-4c80-9ba9-41174ffc0573
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = UtxUsMockLib
+  LIBRARY_CLASS                  = UtCpuOpsMockLib
 
 [Sources]
-  UtxUsMockLib.c
+  UtCpuOpsMockLib.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Library/Mocks/UtSilServicesMockLib/UtSilServicesMockLib.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Library/Mocks/UtSilServicesMockLib/UtSilServicesMockLib.c
@@ -307,3 +307,34 @@ MockSilGetCommon2RevXferTableOnce (
   will_return (SilGetCommon2RevXferTable, ExpectedXferTable);
   will_return (SilGetCommon2RevXferTable, ExpectedSilStatus);
 }
+
+/**
+ * MockSilGetCommon2RevXferTableManyTimes
+ *
+ * @brief Arm expected return value for a single call to SilGetCommon2RevXferTable
+ *
+ * @param ExpectedXferTable  The expected return value from SilGetCommon2RevXferTable.
+ *
+ *                        - In a passing case, this parameter should be a pointer to a buffer for the transfer table.
+ *                        - In a failing case, this parameter should be NULL.
+ *
+ * @param ExpectedSilStatus  The expected return Status from SilGetCommon2RevXferTable.
+ *
+ *                        - In a passing case, this parameter should SilPass.
+ *                        - In a failing case, this parameter should an error Status.
+ */
+void
+MockSilGetCommon2RevXferTableManyTimes (
+  void            *ExpectedXferTable,
+  SIL_STATUS      ExpectedSilStatus,
+  uint32_t        Count 
+  )
+{
+  for(uint32_t i = 0; i < Count; i++)
+  {
+    // Verify IpId is within the range defined by SIL_DATA_BLOCK_ID
+    expect_in_range (SilGetCommon2RevXferTable, IpId, (uint32_t)SilId_SocCommon, ((uint32_t)SilId_ListEnd - 1));
+    will_return (SilGetCommon2RevXferTable, ExpectedXferTable);
+    will_return (SilGetCommon2RevXferTable, ExpectedSilStatus);
+  }
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Library/Mocks/UtxUsMockLib/UtxUsMockLib.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Library/Mocks/UtxUsMockLib/UtxUsMockLib.c
@@ -1,0 +1,41 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file  UtIoMockLib.c
+ * @brief xUs Mock Library
+ *
+ */
+
+#include <Uefi.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <Io.h>
+
+bool 
+xUslIsComputeUnitPrimary (
+    void
+    ) 
+{
+  return mock_type(bool);
+}
+
+/**
+* xUslIsComputeUnitPrimary (Mock)
+*
+* @brief Mocks xUslIsComputeUnitPrimary function returning ture or false
+*
+* @param[in] ExpectedValue  Expected value which is return by xUslIsComputeUnitPrimary()
+*
+*/
+void 
+MockxUslIsComputeUnitPrimary(
+    bool ExpectedValue
+    )
+{
+    will_return(xUslIsComputeUnitPrimary, ExpectedValue);
+}
+
+
+

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Library/Mocks/UtxUsMockLib/UtxUsMockLib.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Library/Mocks/UtxUsMockLib/UtxUsMockLib.inf
@@ -1,0 +1,23 @@
+# Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  UtxUsMockLib.inf
+# @brief
+#
+
+[Defines]
+  INF_VERSION                    = 0x00010006
+  BASE_NAME                      = UtxUsMockLib
+  FILE_GUID                      = ab32c5b9-1d9a-4c80-9ba9-41174ffc0573
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = UtxUsMockLib
+
+[Sources]
+  UtxUsMockLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
@@ -52,7 +52,29 @@
   {
     "Component": "NBIO",
     "Description": "Profile for xUSL NBIO components",
-    "Tests" : []
+    "Tests" : [
+      {
+        "Name"       : "FindPcieCoreDescUt",
+        "ConfigFile" : "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\NBIO\\IOD\\FindPcieCoreDescUt\\FindPcieCoreDescUt.json",
+        "Iterations" : ["ValidFindPcieCoreDesc", "HideInfoThisPcieCoreIsNULL", "HideInfoNextPcieCoreIsNULL"],
+        "Target"     : "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\NBIO\\IOD\\NbioHidePcieCore.c",
+        "Timeout"    : 15
+      },      
+      {
+        "Name"       : "FindLastPciePortOnPrevPcieCUt",
+        "ConfigFile" : "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\NBIO\\IOD\\FindLastPciePortOnPrevPcieCUt\\FindLastPciePortOnPrevPcieCUt.json",
+        "Iterations" : ["ValidFindLastPciePort"],
+        "Target"     : "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\NBIO\\IOD\\NbioHidePcieCore.c",
+        "Timeout"    : 15
+      },
+      {
+        "Name"       : "FindLastPciePortOfThisPcieCUt",
+        "ConfigFile" : "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\NBIO\\IOD\\FindLastPciePortOfThisPcieCUt\\FindLastPciePortOfThisPcieCUt.json",
+        "Iterations" : ["FindLastPciePortOfThisPcieCore"],
+        "Target"     : "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\NBIO\\IOD\\NbioHidePcieCore.c",
+        "Timeout"    : 15
+      }
+    ]
   },
   {
     "Component": "GFX",

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
@@ -113,6 +113,22 @@
   {
     "Component": "DF",
     "Description": "Profile for xUSL DF components",
-    "Tests" : []
+    "Tests" : [
+      {
+        "Name"       : "DfGetProcessorInfoUt",
+        "ConfigFile" : "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\Df\\Common\\DfGetProcessorInfoUt\\DfGetProcessorInfoUt.json",
+        "Iterations" : ["ValidateProcessorInfo", "InvalidSocketIndexParameter"],
+        "Target"     : "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\DF\\Common\\BaseFabricTopologyCmn.c",    
+        "Timeout"    : 15
+      },
+      {
+        "Name"       : "DfGetDieInfoUt",
+        "ConfigFile" : "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\Df\\Common\\DfGetDieInfoUt\\DfGetDieInfoUt.json",
+        "Iterations" : ["ValidateDieInfo", "InvalidSocketParameter", "InvalidDieParameter"],
+        "Target"     : "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\DF\\Common\\BaseFabricTopologyCmn.c",    
+        "Timeout"    : 15
+      }
+    ]
   }
 ]
+

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
@@ -73,6 +73,26 @@
         "Iterations" : ["FindLastPciePortOfThisPcieCore"],
         "Target"     : "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\NBIO\\IOD\\NbioHidePcieCore.c",
         "Timeout"    : 15
+      },
+      
+      {
+        "Name"       : "PcieConfigAttachDescriptorsUt",
+        "ConfigFile" : "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\NBIO\\IOD\\PcieConfigAttachDescriptorsUt\\PcieConfigAttachDescriptorsUt.json",
+        "Iterations" : ["ValidDescriptorRemoved"],
+        "Target"     : "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\NBIO\\IOD\\NbioHidePcieCore.c",
+        "Timeout"    : 15
+      },      {
+        "Name"       : "FindPrevPcieCoreUt",
+        "ConfigFile" : "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\NBIO\\IOD\\FindPrevPcieCoreUt\\FindPrevPcieCoreUt.json",
+        "Iterations" : ["InvalidInstanceID", "FindPrevSiliconAndLastWrapper", "TraverseMultipleSilicons", "PrevSiliconNotFound"],
+        "Target"     : "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\NBIO\\IOD\\NbioHidePcieCore.c",
+        "Timeout"    : 15
+      },      {
+        "Name"       : "IsSteppingAxUt",
+        "ConfigFile" : "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\NBIO\\IOD\\IsSteppingAxUt\\IsSteppingAxUt.json",
+        "Iterations" : ["SilPass", "SilInvalidParameter"],
+        "Target"     : "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\NBIO\\IOD\\NbioBaseInitGenoa.c",
+        "Timeout"    : 15
       }
     ]
   },

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
@@ -127,6 +127,13 @@
         "Iterations" : ["ValidateDieInfo", "InvalidSocketParameter", "InvalidDieParameter"],
         "Target"     : "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\DF\\Common\\BaseFabricTopologyCmn.c",    
         "Timeout"    : 15
+      },
+      {
+        "Name"       : "DfGetSystemInfoUt",
+        "ConfigFile" : "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\Df\\Common\\DfGetSystemInfoUt\\DfGetSystemInfoUt.json",
+        "Iterations" : ["SilPass"],
+        "Target"     : "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\DF\\Common\\BaseFabricTopologyCmn.c",    
+        "Timeout"    : 15
       }
     ]
   }

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
@@ -93,7 +93,23 @@
         "Iterations" : ["SilPass", "SilInvalidParameter"],
         "Target"     : "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\NBIO\\IOD\\NbioBaseInitGenoa.c",
         "Timeout"    : 15
+      },
+      {
+        "Name"       : "PcieEnumerateAndHarvestWrUt",
+        "ConfigFile" : "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\NBIO\\IOD\\PcieEnumerateAndHarvestWrUt\\PcieEnumerateAndHarvestWrUt.json",
+        "Iterations" : ["TestAXStepping", "TestBXStepping"],
+        "Target"     : "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\NBIO\\IOD\\NbioBaseInitGenoa.c",
+        "Timeout"    : 15
+      },
+      
+      {
+        "Name"       : "InitNbioConfigDataUt",
+        "ConfigFile" : "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\NBIO\\IOD\\InitNbioConfigDataUt\\InitNbioConfigDataUt.json",
+        "Iterations" : ["InitDataSuccess"],
+        "Target"     : "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\NBIO\\IOD\\NbioData.c",
+        "Timeout"    : 15
       }
+
     ]
   },
   {

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
@@ -96,14 +96,14 @@
       },
       {
         "Name"       : "CcxSetCacWeightsUt",
-        "ConfigFile" : "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\Ccx\\Common\\CcxSetCacWeightsUtUt\\CcxSetCacWeightsUt.json",
+        "ConfigFile" : "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\Ccx\\Common\\CcxSetCacWeightsUt\\CcxSetCacWeightsUt.json",
         "Iterations" : ["xUslIsComputeUnitPrimaryTrue", "xUslIsComputeUnitPrimaryFalse"],
         "Target"     : "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\CCX\\Common\\CcxMiscInit.c",
         "Timeout"    : 15
       },
       {
         "Name"       : "CcxGetCacWeightsUt",
-        "ConfigFile" : "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\Ccx\\Common\\CcxGetCacWeightsUtUt\\CcxGetCacWeightsUt.json",
+        "ConfigFile" : "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\Ccx\\Common\\CcxGetCacWeightsUt\\CcxGetCacWeightsUt.json",
         "Iterations" : ["SilPass", "SilAborted"],
         "Target"     : "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\CCX\\Common\\CcxMiscInit.c",
         "Timeout"    : 15

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/SoC/Common/SilCmnProf.json
@@ -86,7 +86,29 @@
   {
     "Component": "CCX",
     "Description": "Profile for xUSL CCX components",
-    "Tests" : []
+    "Tests" : [
+      {
+        "Name"       : "CcxEnableSmeeUt",
+        "ConfigFile" : "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\Ccx\\Common\\CcxEnableSmeeUt\\CcxEnableSmeeUt.json",
+        "Iterations" : ["EnableSmeeTrue", "EnableSmeeFalse"],
+        "Target"     : "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\CCX\\Common\\CcxMiscInit.c",
+        "Timeout"    : 15
+      },
+      {
+        "Name"       : "CcxSetCacWeightsUt",
+        "ConfigFile" : "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\Ccx\\Common\\CcxSetCacWeightsUtUt\\CcxSetCacWeightsUt.json",
+        "Iterations" : ["xUslIsComputeUnitPrimaryTrue", "xUslIsComputeUnitPrimaryFalse"],
+        "Target"     : "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\CCX\\Common\\CcxMiscInit.c",
+        "Timeout"    : 15
+      },
+      {
+        "Name"       : "CcxGetCacWeightsUt",
+        "ConfigFile" : "AmdOpenSilPkg\\opensil-uefi-interface\\UnitTest\\Source\\xUSL\\Ccx\\Common\\CcxGetCacWeightsUtUt\\CcxGetCacWeightsUt.json",
+        "Iterations" : ["SilPass", "SilAborted"],
+        "Target"     : "AmdOpenSilPkg\\opensil-uefi-interface\\OpenSIL\\xUSL\\CCX\\Common\\CcxMiscInit.c",
+        "Timeout"    : 15
+      }
+    ]
   },
   {
     "Component": "DF",

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxEnableSmeeUt/CcxEnableSmeeUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxEnableSmeeUt/CcxEnableSmeeUt.c
@@ -1,0 +1,196 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file CcxEnableSmeeUt.c
+ * @brief
+ *
+ */
+
+#include <CcxEnableSmeeUt.h>
+
+void
+xUslMsrAndThenOr (
+  uint32_t Index,
+  uint64_t AndData,
+  uint64_t OrData
+  )
+{
+  return;
+}
+
+uint64_t 
+xUslRdMsr (
+  uint32_t MsrAddress
+  )
+{
+  return 0;
+}
+
+void 
+xUslWrMsr (
+  uint32_t MsrAddress, 
+  uint64_t MsrValue
+  )
+{
+  return;
+}
+
+void 
+xUslMsrOr (
+  uint32_t Index, 
+  uint64_t OrData)
+{
+  return;
+}
+
+void 
+xUslMsrAnd (
+  uint32_t Index, 
+  uint64_t AndData
+  )
+{
+  return;
+}
+
+bool 
+xUslIsComputeUnitPrimary (
+  void
+  ) 
+{
+  return TRUE;
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED; 
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  bool SmeeEnable = 0;
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+
+  if (strcmp (IterationName, "EnableSmeeTrue") == 0) {
+    // Arrange 
+    SmeeEnable = 1;
+
+    // Act  
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+      "Call CcxEnableSmee()");
+    CcxEnableSmee(SmeeEnable);
+
+    // Assert
+    //There is no status returned from CcxEnableSmee. 
+    //Just test if function crush and catch by UT API
+
+  } else if (strcmp (IterationName, "EnableSmeeFalse") == 0) {
+    // Arrange 
+    SmeeEnable = 0;
+
+    // Act  
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+      "Call CcxEnableSmee()");
+    CcxEnableSmee(SmeeEnable);
+
+    // Assert 
+    //There is no status returned from CcxEnableSmee. 
+    //Just test if function crush and catch by UT API
+  } else {
+    Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+      "Iteration '%s' is not implemented.", IterationName);
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+  }
+  
+  UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  // AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  // const char* TestName        = UtGetTestName (Ut);
+  // const char* IterationName   = UtGetTestIteration (Ut);
+  // Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+  //   "%s (Iteration: %s) CleanUp started.", TestName, IterationName);
+  // // Free openSIL allocated memory
+  // UtSilDeinit ();
+  // Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+  //   "%s (Iteration: %s) CleanUp ended.", TestName, IterationName);
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Stating point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  // char *SimpleCharContext = "A simple TestBody context";
+
+  // Logging the start of the test.
+  // Note: Test status at this time is set to "NOT_SET".
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // You can pass into the TestPrerequisite, TestBody, and TestCleanUp context of
+  // your desire
+  // UtSetTestContext (&Ut, (AMD_UNIT_TEST_CONTEXT)SimpleCharContext);
+
+  // Running the test
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxEnableSmeeUt/CcxEnableSmeeUt.h
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxEnableSmeeUt/CcxEnableSmeeUt.h
@@ -1,0 +1,20 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file  CcxEnableSmeeUt.h
+ * @brief
+ *
+ */
+
+#pragma once
+
+#include <UtBaseLib.h>
+#include <UtSilInitLib.h>
+#include <UtLogLib.h>
+
+#include <stdlib.h>     
+#include <time.h>       
+#include <stdbool.h>    
+#include <xSIM.h>       
+#include <CCX/Common/Ccx.h> 
+#include <Include/MsrReg.h>

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxEnableSmeeUt/CcxEnableSmeeUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxEnableSmeeUt/CcxEnableSmeeUt.inf
@@ -1,0 +1,34 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  CcxEnableSmeeUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = CcxEnableSmeeUt
+  FILE_GUID      = 4bda8fa4-6020-401b-976f-ea0c3fcf7f4f
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[Sources]
+  CcxEnableSmeeUt.c
+  CcxEnableSmeeUt.h
+  ../../../../../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/CCX/Common/CcxMiscInit.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtSilServicesMockLib
+
+  UtIoFakeLib
+  UtSilInitLib
+  UtMmioFakeLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxEnableSmeeUt/CcxEnableSmeeUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxEnableSmeeUt/CcxEnableSmeeUt.json
@@ -1,0 +1,11 @@
+[
+    {
+      "Description": "Excutes function CcxEnableSmee() successfully with Ture parameter",
+      "Iteration": "EnableSmeeTrue"
+    },
+    {
+      "Description": "Excutes function CcxEnableSmee() successfully with False parameter",
+      "Iteration": "EnableSmeeFalse"
+    }
+]
+  

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxGetCacWeightsUt/CcxGetCacWeightsUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxGetCacWeightsUt/CcxGetCacWeightsUt.c
@@ -1,0 +1,219 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file CcxGetCacWeightsUt.c
+ * @brief
+ *
+ */
+
+#include <UtBaseLib.h>
+#include <UtSilInitLib.h>
+#include <UtLogLib.h>
+
+#include <stdlib.h>     // if not included, build ok
+#include <time.h>       // if not included, build ok
+#include <stdbool.h>    // if not included, build ok
+#include <xSIM.h>       // if not included, will cause error 2059, c2061
+#include <CCX/Common/Ccx.h> //must put here, solve the error of undefine of CcxEnableSmee
+#include <Include/MsrReg.h>// if not included, build ok
+
+// HOST_DEBUG_SERVICE mHostDebugService = NULL;
+void
+xUslMsrAndThenOr (
+  uint32_t Index,
+  uint64_t AndData,
+  uint64_t OrData
+  )
+{
+  return;
+}
+
+uint64_t 
+xUslRdMsr (
+  uint32_t MsrAddress
+  )
+{
+  return 0;
+}
+
+void 
+xUslWrMsr (
+  uint32_t MsrAddress, 
+  uint64_t MsrValue
+  )
+{
+  return;
+}
+
+void 
+xUslMsrOr (
+  uint32_t Index, 
+  uint64_t OrData)
+{
+  return;
+}
+
+void 
+xUslMsrAnd (
+  uint32_t Index, 
+  uint64_t AndData
+  )
+{
+  return;
+}
+
+bool 
+xUslIsComputeUnitPrimary (
+  void
+  ) 
+{
+  return TRUE;
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED; 
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  SIL_STATUS           SilStatus;
+  SIL_DATA_BLOCK_ID ipId = SilId_SocCommon;
+  
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+
+  if (strcmp (IterationName, "SilPass") == 0) {
+    // Arrange for SilGetIp2IpApi (SilId_SmuClass, (void **)&SmuApi) in CcxGetCacWeights (uint64_t *CacWeights);
+    // mock func -> SilGetIp2IpApi (SIL_DATA_BLOCK_ID IpId, void **Api);
+    void *validApi = NULL;
+    uint64_t CacWeightsGet[5] ={0, 236, 93671, 32447, 46512};
+
+    SilGetIp2IpApi (ipId, &validApi);
+
+    // Act  
+    SilStatus = CcxGetCacWeights(CacWeightsGet);
+
+    // Assert
+    if (SilStatus != SilPass) {
+      Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+            "Did not receive SilPass", IterationName);
+      UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    } else {
+      UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+    }
+  } else if (strcmp (IterationName, "SilAborted") == 0) {
+    // Arrange 
+    void **invalidApi = NULL; //pass as invalidApi
+    uint64_t CacWeightsGet[5] ={0, 236, 93671, 32447, 46512};
+
+    SilGetIp2IpApi (ipId, invalidApi);
+
+    // Act  
+    SilStatus = CcxGetCacWeights(CacWeightsGet);
+
+    // Assert 
+    if (SilStatus != SilPass) {
+      Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+            "Did not receive SilPass", IterationName);
+      UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    } else {
+      UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+    }
+  } else {
+    Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+      "Iteration '%s' is not implemented.", IterationName);
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+  }
+
+  UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  // AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  // const char* TestName        = UtGetTestName (Ut);
+  // const char* IterationName   = UtGetTestIteration (Ut);
+  // Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+  //   "%s (Iteration: %s) CleanUp started.", TestName, IterationName);
+  // // Free openSIL allocated memory
+  // UtSilDeinit ();
+  // Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+  //   "%s (Iteration: %s) CleanUp ended.", TestName, IterationName);
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Stating point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  // char *SimpleCharContext = "A simple TestBody context";
+
+  // Logging the start of the test.
+  // Note: Test status at this time is set to "NOT_SET".
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // You can pass into the TestPrerequisite, TestBody, and TestCleanUp context of
+  // your desire
+  // UtSetTestContext (&Ut, (AMD_UNIT_TEST_CONTEXT)SimpleCharContext);
+
+  // Running the test
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxGetCacWeightsUt/CcxGetCacWeightsUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxGetCacWeightsUt/CcxGetCacWeightsUt.c
@@ -96,42 +96,19 @@ TestBody (
     "%s (Iteration: %s) Test started.", TestName, IterationName);
 
   if (strcmp (IterationName, "SilPass") == 0) {
-    // Arrange for SilGetIp2IpApi (SilId_SmuClass, (void **)&SmuApi) in CcxGetCacWeights (uint64_t *CacWeights);
-    // mock func -> SilGetIp2IpApi (SIL_DATA_BLOCK_ID IpId, void **Api);
-    void *validApi = NULL;
-    uint64_t CacWeightsGet[5] ={0, 236, 93671, 32447, 46512};
-
-    SilGetIp2IpApi (ipId, &validApi);
+    // Arrange 
 
     // Act  
-    SilStatus = CcxGetCacWeights(CacWeightsGet);
 
     // Assert
-    if (SilStatus != SilPass) {
-      Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
-            "Did not receive SilPass", IterationName);
-      UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
-    } else {
-      UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
-    }
+
   } else if (strcmp (IterationName, "SilAborted") == 0) {
     // Arrange 
-    void **invalidApi = NULL; //pass as invalidApi
-    uint64_t CacWeightsGet[5] ={0, 236, 93671, 32447, 46512};
-
-    SilGetIp2IpApi (ipId, invalidApi);
 
     // Act  
-    SilStatus = CcxGetCacWeights(CacWeightsGet);
 
     // Assert 
-    if (SilStatus != SilPass) {
-      Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
-            "Did not receive SilPass", IterationName);
-      UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
-    } else {
-      UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
-    }
+
   } else {
     Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
       "Iteration '%s' is not implemented.", IterationName);

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxGetCacWeightsUt/CcxGetCacWeightsUt.h
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxGetCacWeightsUt/CcxGetCacWeightsUt.h
@@ -1,0 +1,9 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file  CcxGetCacWeightsUt.h
+ * @brief
+ *
+ */
+
+#pragma once

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxGetCacWeightsUt/CcxGetCacWeightsUt.h
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxGetCacWeightsUt/CcxGetCacWeightsUt.h
@@ -7,3 +7,19 @@
  */
 
 #pragma once
+
+#include <UtBaseLib.h>
+#include <UtSilInitLib.h>
+#include <UtLogLib.h>
+#include <stdlib.h>     
+#include <time.h>       
+#include <stdbool.h>    
+#include <xSIM.h>       
+#include <CCX/Common/Ccx.h> 
+#include <Include/MsrReg.h>
+#include <Include/Library/UtSilServicesMockLib.h>
+
+SIL_STATUS SmuReadCacWeightsUt (
+  uint32_t  MaxNumWeights,
+  uint64_t  *ApmWeights
+);

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxGetCacWeightsUt/CcxGetCacWeightsUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxGetCacWeightsUt/CcxGetCacWeightsUt.inf
@@ -1,0 +1,35 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  CcxGetCacWeightsUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = CcxGetCacWeightsUt
+  FILE_GUID      = e643a68d-e6fe-4d46-9ab4-1b97c32e64f2
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[Sources]
+  CcxGetCacWeightsUt.c
+  CcxGetCacWeightsUt.h
+  ../../../../../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/CCX/Common/CcxMiscInit.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtSilServicesMockLib
+  
+
+  UtIoFakeLib
+  UtSilInitLib
+  UtMmioFakeLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxGetCacWeightsUt/CcxGetCacWeightsUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxGetCacWeightsUt/CcxGetCacWeightsUt.inf
@@ -5,13 +5,17 @@
 # @brief
 #
 
-
 [Defines]
   INF_VERSION    = 0x00010005
   BASE_NAME      = CcxGetCacWeightsUt
   FILE_GUID      = e643a68d-e6fe-4d46-9ab4-1b97c32e64f2
   MODULE_TYPE    = HOST_APPLICATION
   VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h /Dstatic=
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h -Dstatic=
 
 [Sources]
   CcxGetCacWeightsUt.c
@@ -28,8 +32,8 @@
 [LibraryClasses]
   UtBaseLib
   UtSilServicesMockLib
-  
-
+  UtCpuOpsMockLib
   UtIoFakeLib
   UtSilInitLib
   UtMmioFakeLib
+  UtPciStubLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxGetCacWeightsUt/CcxGetCacWeightsUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxGetCacWeightsUt/CcxGetCacWeightsUt.json
@@ -1,0 +1,11 @@
+[
+    {
+      "Description": "Excutes  CcxGetCacWeights() and successfully returns SilPass",
+      "Iteration": "SilPass"
+    },
+    {
+      "Description": "Excutes  CcxGetCacWeights() and successfully returns SilAborted",
+      "Iteration": "SilAborted"
+  }
+]
+  

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxSetCacWeightsUt/CcxSetCacWeightsUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxSetCacWeightsUt/CcxSetCacWeightsUt.c
@@ -113,15 +113,6 @@ TestCleanUp (
   IN AMD_UNIT_TEST_CONTEXT Context
   )
 {
-  // AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
-  // const char* TestName        = UtGetTestName (Ut);
-  // const char* IterationName   = UtGetTestIteration (Ut);
-  // Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
-  //   "%s (Iteration: %s) CleanUp started.", TestName, IterationName);
-  // // Free openSIL allocated memory
-  // UtSilDeinit ();
-  // Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
-  //   "%s (Iteration: %s) CleanUp ended.", TestName, IterationName);
   return AMD_UNIT_TEST_PASSED;
 }
 

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxSetCacWeightsUt/CcxSetCacWeightsUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxSetCacWeightsUt/CcxSetCacWeightsUt.c
@@ -1,0 +1,183 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file CcxSetCacWeightsUt.c
+ * @brief
+ *
+ */
+#include <CcxSetCacWeightsUt.h>
+
+void
+xUslMsrAndThenOr (
+  uint32_t Index,
+  uint64_t AndData,
+  uint64_t OrData
+  )
+{
+  return;
+}
+
+uint64_t 
+xUslRdMsr (
+  uint32_t MsrAddress
+  )
+{
+  return 0;
+}
+
+void 
+xUslWrMsr (
+  uint32_t MsrAddress, 
+  uint64_t MsrValue
+  )
+{
+  return;
+}
+
+void 
+xUslMsrOr (
+  uint32_t Index, 
+  uint64_t OrData)
+{
+  return;
+}
+
+void 
+xUslMsrAnd (
+  uint32_t Index, 
+  uint64_t AndData
+  )
+{
+  return;
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  return AMD_UNIT_TEST_PASSED; 
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  uint64_t CacWeights[MAX_CAC_WEIGHT_NUM] ={0};
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+
+  if (strcmp (IterationName, "xUslIsComputeUnitPrimaryTrue") == 0) {
+    // Arrange 
+    MockxUslIsComputeUnitPrimary(true);
+    
+    // Act  
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+      "Call CcxSetCacWeights()");
+    CcxSetCacWeights(CacWeights);
+
+    // Assert
+
+  } else if (strcmp (IterationName, "xUslIsComputeUnitPrimaryFalse") == 0) {
+    // Arrange 
+    MockxUslIsComputeUnitPrimary(false);
+
+    // Act  
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+      "Call CcxSetCacWeights()");
+    CcxSetCacWeights(CacWeights);
+
+    // Assert 
+  } else {
+    Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+      "Iteration '%s' is not implemented.", IterationName);
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+  }
+  
+  UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  // AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  // const char* TestName        = UtGetTestName (Ut);
+  // const char* IterationName   = UtGetTestIteration (Ut);
+  // Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+  //   "%s (Iteration: %s) CleanUp started.", TestName, IterationName);
+  // // Free openSIL allocated memory
+  // UtSilDeinit ();
+  // Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+  //   "%s (Iteration: %s) CleanUp ended.", TestName, IterationName);
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Stating point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  // char *SimpleCharContext = "A simple TestBody context";
+
+  // Logging the start of the test.
+  // Note: Test status at this time is set to "NOT_SET".
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // You can pass into the TestPrerequisite, TestBody, and TestCleanUp context of
+  // your desire
+  // UtSetTestContext (&Ut, (AMD_UNIT_TEST_CONTEXT)SimpleCharContext);
+
+  // Running the test
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxSetCacWeightsUt/CcxSetCacWeightsUt.h
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxSetCacWeightsUt/CcxSetCacWeightsUt.h
@@ -19,4 +19,4 @@
 #include <CCX/Common/Ccx.h> 
 #include <Include/MsrReg.h>
 #include <Library/UtSilServicesMockLib.h>
-#include <Library/UtxUsMockLib.h>
+#include <Library/UtCpuOpsMockLib.h>

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxSetCacWeightsUt/CcxSetCacWeightsUt.h
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxSetCacWeightsUt/CcxSetCacWeightsUt.h
@@ -1,0 +1,22 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file  CcxSetCacWeightsUt.h
+ * @brief
+ *
+ */
+
+#pragma once
+
+#include <SilCommon.h>
+#include <UtBaseLib.h>
+#include <UtSilInitLib.h>
+#include <UtLogLib.h>
+#include <stdlib.h>     
+#include <time.h>       
+#include <stdbool.h>    
+#include <xSIM.h>       
+#include <CCX/Common/Ccx.h> 
+#include <Include/MsrReg.h>
+#include <Library/UtSilServicesMockLib.h>
+#include <Library/UtxUsMockLib.h>

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxSetCacWeightsUt/CcxSetCacWeightsUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxSetCacWeightsUt/CcxSetCacWeightsUt.inf
@@ -28,7 +28,7 @@
 [LibraryClasses]
   UtBaseLib
   UtSilServicesMockLib
-  UtxUsMockLib
+  UtCpuOpsMockLib
 
   UtIoFakeLib
   UtSilInitLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxSetCacWeightsUt/CcxSetCacWeightsUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxSetCacWeightsUt/CcxSetCacWeightsUt.inf
@@ -1,0 +1,35 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  CcxSetCacWeightsUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = CcxSetCacWeightsUt
+  FILE_GUID      = 509345be-6d5d-4914-9f2a-25dc53d6eccd
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[Sources]
+  CcxSetCacWeightsUt.c
+  CcxSetCacWeightsUt.h
+  ../../../../../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/CCX/Common/CcxMiscInit.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtSilServicesMockLib
+  UtxUsMockLib
+
+  UtIoFakeLib
+  UtSilInitLib
+  UtMmioFakeLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxSetCacWeightsUt/CcxSetCacWeightsUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Ccx/Common/CcxSetCacWeightsUt/CcxSetCacWeightsUt.json
@@ -1,0 +1,10 @@
+[
+    {
+      "Description": "Excutes  CcxSetCacWeights() when xUslIsComputeUnitPrimary() return true",
+      "Iteration": "xUslIsComputeUnitPrimaryTrue"
+    },
+    {
+      "Description": "Excutes  CcxSetCacWeights() when xUslIsComputeUnitPrimary() return false",
+      "Iteration": "xUslIsComputeUnitPrimaryFalse"
+    }
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetDieInfoUt/DfGetDieInfoUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetDieInfoUt/DfGetDieInfoUt.c
@@ -1,0 +1,237 @@
+/* SPDX-License-Identifier: MIT */
+/* Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved. */
+/**
+* @file DfGetDieInfoUt.c
+* @brief
+*
+* This function retrieves information about the given die.
+*
+* 5 iterations
+*
+*/
+#include "DfGetDieInfoUt.h"
+
+HOST_DEBUG_SERVICE mHostDebugService = NULL;
+
+DF_COMMON_2_REV_XFER_BLOCK DfCmn2RevXfer = {
+  .DfFabricRegisterAccRead                =         NULL,
+  .DfFabricRegisterAccWrite               =         NULL,
+  .DfGetNumberOfProcessorsPresent         =         GetNumberOfProcessorsPresentUt,
+  .DfGetNumberOfSystemDies                =         NULL,
+  .DfGetNumberOfSystemRootBridges         =         NULL,
+  .DfGetNumberOfRootBridgesOnSocket       =         NULL, 
+  .DfGetNumberOfRootBridgesOnDie          =         GetNumberOfRootBridgesOnDieUt,
+  .DfGetDieSystemOffset                   =         GetDieSystemOffsetUt,
+  .DfGetDeviceMapOnDie                    =         GetDeviceMapOnDieUt,
+  .DfGetHostBridgeBusBase                 =         NULL,
+  .DfGetHostBridgeBusLimit                =         NULL,
+  .DfGetPhysRootBridgeNumber              =         NULL,
+  .DfFindComponentLocationMap             =         NULL,
+  .DfBaseFabricTopologyConstructor        =         NULL,
+  .DfBuildDomainInfo                      =         NULL
+};
+
+UINT32
+GetNumberOfProcessorsPresentUt (
+  void
+  )
+{
+  return 1;
+}
+
+UINT32 
+GetNumberOfRootBridgesOnDieUt (
+  UINT32 Socket
+  ) 
+{
+  return 1;
+};
+
+UINT32 
+GetDieSystemOffsetUt (
+  UINT32 Socket
+  )
+{
+  return 1;
+}
+
+CONST 
+AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP* 
+  GetDeviceMapOnDieUt (
+  void
+  )
+{
+  return NULL; //or {type = NULL; Count = 0; *IDs = NULL} 
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_STATUS Status = AMD_UNIT_TEST_PASSED;
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Prerequisite started.", TestName, IterationName);
+  Status = UtSilInit ();
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return AMD_UNIT_TEST_ABORTED;
+  }
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Allocating memory for openSIL.");
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut            = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName                   = UtGetTestName (Ut);
+  const char* IterationName              = UtGetTestIteration (Ut);
+
+  UINT32 NumberOfRootBridges;
+  UINT32 SystemIdOffset;
+  const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP *FabricIdMap;
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+
+  if (strcmp(IterationName, "ValidateDieInfo") == 0) {
+    // Setting up SilGetCommon2RevXferTable to pass.
+    // SilGetCommon2RevXferTable from DfGetDieInfo()
+    MockSilGetCommon2RevXferTableOnce ((void *)&DfCmn2RevXfer, SilPass);
+
+    DfGetDieInfo (0, 0, &NumberOfRootBridges, &SystemIdOffset, &FabricIdMap);
+
+    // Assert
+    // These should both be 1 given that we return 1 in our stub functions
+    if ((NumberOfRootBridges != 1) && (SystemIdOffset != 1) && (FabricIdMap == NULL)) {
+      Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+        "Status (0x%x) ValidateProcessorInfo test fail.", IterationName);
+      UtSetTestStatus (Ut, AMD_UNIT_TEST_FAILED);
+    }else {
+      Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+         "Status (0x%x) ValidateProcessorInfo test pass.", IterationName);
+      UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+    }
+    
+  } else if(strcmp(IterationName, "InvalidSocketParameter") == 0){
+    //Arrange an invalid Socket which is more than 1 according to the stub function
+    UINT32 Socket = 1;
+
+    MockSilGetCommon2RevXferTableOnce ((void *)&DfCmn2RevXfer, SilPass);
+
+    DfGetDieInfo (Socket, 0, &NumberOfRootBridges, &SystemIdOffset, &FabricIdMap);
+
+    //Assert
+    //Socket should be less than 1 because we return 1 in our stub function
+    if(Socket >= 1){
+      Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+         "Status (0x%x) InvalidSocketIndexParameter test pass.", IterationName, Socket);
+      UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+    }else{
+      Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+        "Status (0x%x) InvalidSocketIndexParameter test fail.", IterationName);
+      UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+
+  }else if(strcmp(IterationName, "InvalidDieParameter") == 0){
+    //Arrange an invalid Die which is more than 1 according to the stub function
+    UINT32  Die = 1;
+
+    MockSilGetCommon2RevXferTableOnce ((void *)&DfCmn2RevXfer, SilPass);
+
+    DfGetDieInfo (0, Die, &NumberOfRootBridges, &SystemIdOffset, &FabricIdMap);
+
+    //Assert
+    //Die should be less than 1 because we return 1 in our stub function
+    if(Die >= 1){
+      Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+         "Status (0x%x) InvalidSocketIndexParameter test pass.", IterationName, Die);
+      UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+    }else{
+      Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+        "Status (0x%x) InvalidSocketIndexParameter test fail.", IterationName);
+      UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+
+  }else {
+    Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__, "Iteration '%s' is not implemented.", IterationName);
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+  }
+
+  UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Freeing memory allocated to openSIL.");
+  UtSilDeinit ();
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+* main
+* @brief      Stating point for Execution
+*
+* @details    This routine:
+*              - Handles the command line arguments.
+*                example: DfGetDieInfoUt.exe -o "E:\test" -i
+*                         "ValidateProcessorInfo" -c <Path to Test Config File>
+*              - Declares the unit test framework.
+*              - Run the tests.
+*              - Deallocate the Unit test framework.
+*
+* @param    argc                     Argument count
+* @param    *argv[]                  Argument vector
+*
+* @retval   AMD_UNIT_TEST_PASSED     Function succeeded
+* @retval   NON-ZERO                 Error occurs
+*/
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS     Status;
+  AMD_UNIT_TEST_FRAMEWORK  Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  // Logging the start of the test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // Running the test
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}
+ 

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetDieInfoUt/DfGetDieInfoUt.h
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetDieInfoUt/DfGetDieInfoUt.h
@@ -1,0 +1,38 @@
+/* SPDX-License-Identifier: MIT */
+/* Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved. */
+/**
+* @file DfGetDieInfoUt.h
+* @brief
+*
+*/
+
+#include <xPRF-api.h>
+#include <UtBaseLib.h>
+#include <UtSilInitLib.h>
+#include <UtLogLib.h>
+#include <Library/UtSilServicesMockLib.h>
+#include <DF/Common/DfCmn2Rev.h>
+#include <DF/Common/BaseFabricTopologyCmn.h>
+#include <DF/Common/SilBaseFabricTopologyLib.h>
+
+
+UINT32
+GetNumberOfProcessorsPresentUt (
+  void
+  );
+
+UINT32 
+GetNumberOfRootBridgesOnDieUt (
+  UINT32 Socket
+  );
+
+UINT32 
+GetDieSystemOffsetUt (
+  UINT32 Socket
+  );
+
+CONST
+AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP* //need confirm
+  GetDeviceMapOnDieUt (
+  void
+  );

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetDieInfoUt/DfGetDieInfoUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetDieInfoUt/DfGetDieInfoUt.inf
@@ -1,0 +1,38 @@
+# Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+#
+# @file  DfGetDieInfoUt.inf
+# @brief
+#
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = DfGetDieInfoUt
+  FILE_GUID      = e0f6e1d3-8420-44f3-85e6-953e4b4dd4ea
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h /Dstatic=
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h -Dstatic=
+
+[Sources]
+  DfGetDieInfoUt.c
+  DfGetDieInfoUt.h
+  ../../../../../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/DF/Common/BaseFabricTopologyCmn.c
+  
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtIoFakeLib
+  UtSilInitLib
+  UtSilServicesMockLib
+  UtPciStubLib
+ 

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetDieInfoUt/DfGetDieInfoUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetDieInfoUt/DfGetDieInfoUt.json
@@ -1,0 +1,14 @@
+[
+  {
+    "Description": " Validate Fabric Processor info.",
+    "Iteration"  : "ValidateDieInfo"
+  },
+  {
+    "Description": " Invalid Socket parameter in Fabric Processor info.",
+    "Iteration"  : "InvalidSocketParameter"
+  },
+  {
+    "Description": " Invalid Die parameter in Fabric Processor info.",
+    "Iteration"  : "InvalidDieParameter"
+  }
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetProcessorInfoUt/DfGetProcessorInfoUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetProcessorInfoUt/DfGetProcessorInfoUt.c
@@ -1,0 +1,206 @@
+/* SPDX-License-Identifier: MIT */
+/* Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved. */
+/**
+* @file DfGetProcessorInfoUt.c
+* @brief
+*
+* This function retrieves information about the processor installed in the given socket.
+*
+* 2 iterations
+*
+*/
+#include "DfGetProcessorInfoUt.h"
+
+HOST_DEBUG_SERVICE mHostDebugService = NULL;
+
+DF_COMMON_2_REV_XFER_BLOCK DfCmn2RevXfer = {
+  .DfFabricRegisterAccRead                =         NULL,
+  .DfFabricRegisterAccWrite               =         NULL,
+  .DfGetNumberOfProcessorsPresent         =         GetNumberOfProcessorsPresentUt,
+  .DfGetNumberOfSystemDies                =         GetNumberOfSystemDiesUt,
+  .DfGetNumberOfSystemRootBridges         =         NULL,
+  .DfGetNumberOfRootBridgesOnSocket       =         GetNumberOfRootBridgesOnSocketUt,
+  .DfGetNumberOfRootBridgesOnDie          =         NULL,
+  .DfGetDieSystemOffset                   =         NULL,
+  .DfGetDeviceMapOnDie                    =         NULL,
+  .DfGetHostBridgeBusBase                 =         NULL,
+  .DfGetHostBridgeBusLimit                =         NULL,
+  .DfGetPhysRootBridgeNumber              =         NULL,
+  .DfFindComponentLocationMap             =         NULL,
+  .DfBaseFabricTopologyConstructor        =         NULL,
+  .DfBuildDomainInfo                      =         NULL
+};
+
+UINT32
+GetNumberOfProcessorsPresentUt (
+  void
+  )
+{
+  return 1;
+}
+
+UINT32
+GetNumberOfRootBridgesOnSocketUt (
+  UINT32               Socket
+  )
+{
+  return 1;
+}
+
+UINT32
+GetNumberOfSystemDiesUt (
+  void
+  )
+{
+  return 1;
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_STATUS Status = AMD_UNIT_TEST_PASSED;
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Prerequisite started.", TestName, IterationName);
+  Status = UtSilInit ();
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return AMD_UNIT_TEST_ABORTED;
+  }
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Allocating memory for openSIL.");
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut            = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName                   = UtGetTestName (Ut);
+  const char* IterationName              = UtGetTestIteration (Ut);
+
+  UINT32 SocketIndex;
+  UINT32 DieCount;
+  UINT32 RootBridgeCount;
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+
+  if (strcmp(IterationName, "ValidateProcessorInfo") == 0) {
+    // Setting up SilGetCommon2RevXferTable to pass.
+    // SilGetCommon2RevXferTable from DfGetProcessorInfo()
+    MockSilGetCommon2RevXferTableOnce ((void *)&DfCmn2RevXfer, SilPass);
+
+    DfGetProcessorInfo (0, &DieCount, &RootBridgeCount);
+
+    // Assert
+    // These should both be 1 given that we return 1 in our stub functions
+    if ((DieCount != 1) && (RootBridgeCount != 1)) {
+      Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+        "Status (0x%x) ValidateProcessorInfo test fail.", IterationName);
+      UtSetTestStatus (Ut, AMD_UNIT_TEST_FAILED);
+    }else {
+      Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+         "Status (0x%x) ValidateProcessorInfo test pass.", IterationName);
+      UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+    }
+
+  } else if(strcmp(IterationName, "InvalidSocketIndexParameter") == 0){
+    // Set invalid socktIndex parameter which is less than 1
+    SocketIndex = 1;
+
+    MockSilGetCommon2RevXferTableOnce ((void *)&DfCmn2RevXfer, SilPass);
+
+    DfGetProcessorInfo (SocketIndex, &DieCount, &RootBridgeCount);
+
+    // Assert
+    // Check invalid socktIndex parameter
+    if (SocketIndex < 1) {
+      Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+        "Status (0x%x) InvalidSocketIndexParameter test fail.", IterationName);
+      UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }else {
+      Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+         "Status (0x%x) InvalidSocketIndexParameter test pass.", IterationName);
+      UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+    }
+  } else {
+    Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__, "Iteration '%s' is not implemented.", IterationName);
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+  }
+
+  UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Freeing memory allocated to openSIL.");
+  UtSilDeinit ();
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+* main
+* @brief      Stating point for Execution
+*
+* @details    This routine:
+*              - Handles the command line arguments.
+*                example: DfGetProcessorInfoUt.exe -o "E:\test" -i
+*                         "ValidateProcessorInfo" -c <Path to Test Config File>
+*              - Declares the unit test framework.
+*              - Run the tests.
+*              - Deallocate the Unit test framework.
+*
+* @param    argc                     Argument count
+* @param    *argv[]                  Argument vector
+*
+* @retval   AMD_UNIT_TEST_PASSED     Function succeeded
+* @retval   NON-ZERO                 Error occurs
+*/
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS     Status;
+  AMD_UNIT_TEST_FRAMEWORK  Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  // Logging the start of the test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // Running the test
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}
+ 

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetProcessorInfoUt/DfGetProcessorInfoUt.h
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetProcessorInfoUt/DfGetProcessorInfoUt.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: MIT */
+/* Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved. */
+/**
+* @file DfGetProcessorInfoUt.h
+* @brief
+*
+*/
+
+#include <xPRF-api.h>
+#include <UtBaseLib.h>
+#include <UtSilInitLib.h>
+#include <UtLogLib.h>
+#include <Library/UtSilServicesMockLib.h>
+#include <DF/Common/DfCmn2Rev.h>
+#include <DF/Common/BaseFabricTopologyCmn.h>
+
+
+UINT32
+GetNumberOfProcessorsPresentUt (
+  void
+  );
+
+UINT32
+GetNumberOfRootBridgesOnSocketUt (
+  UINT32               Socket
+  );
+
+UINT32
+GetNumberOfSystemDiesUt (
+  void
+  );
+ 

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetProcessorInfoUt/DfGetProcessorInfoUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetProcessorInfoUt/DfGetProcessorInfoUt.inf
@@ -1,0 +1,38 @@
+# Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+#
+# @file  DfGetProcessorInfoUt.inf
+# @brief
+#
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = DfGetProcessorInfoUt
+  FILE_GUID      = 0d5aa1d6-29a0-4704-b087-175ce753bd12
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h /Dstatic=
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h -Dstatic=
+
+[Sources]
+  DfGetProcessorInfoUt.c
+  DfGetProcessorInfoUt.h
+  ../../../../../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/DF/Common/BaseFabricTopologyCmn.c
+  
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtIoFakeLib
+  UtSilInitLib
+  UtSilServicesMockLib
+  UtPciStubLib
+ 

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetProcessorInfoUt/DfGetProcessorInfoUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetProcessorInfoUt/DfGetProcessorInfoUt.json
@@ -1,0 +1,10 @@
+[
+  {
+    "Description": " Validate Fabric Processor info.",
+    "Iteration"  : "ValidateProcessorInfo"
+  },
+  {
+    "Description": " Invalid SocketInde in Fabric Processor info.",
+    "Iteration"  : "InvalidSocketIndexParameter"
+  }
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetSystemInfoUt/DfGetSystemInfoUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetSystemInfoUt/DfGetSystemInfoUt.c
@@ -1,0 +1,252 @@
+/* SPDX-License-Identifier: MIT */
+/* Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved. */
+/**
+* @file DfGetSystemInfoUt.c
+* @brief
+*
+* This function retrieves information about the given die.
+*
+* 5 iterations
+*
+*/
+#include "DfGetSystemInfoUt.h"
+
+#define FABRIC_REG_ACC_BC    (0xFF) // Data needed for fakes
+
+HOST_DEBUG_SERVICE mHostDebugService = NULL;
+
+// Data needed for fakes
+// Data for DfXFindComponentLocationMap()
+const DEVICE_IDS   GenoaIosMap [] = {
+  {0x00000020, 0x00000024},
+  {0x00000021, 0x00000025},
+  {0x00000022, 0x00000026},
+  {0x00000023, 0x00000027}
+};
+
+const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP  GenoaDeviceMap[] = {
+  {Ios,   sizeof (GenoaIosMap) / sizeof (GenoaIosMap[0]),      &GenoaIosMap[0]    },
+  {FabricDeviceTypeMax, 0, NULL}
+};
+
+// Data for DfXFindComponentLocationMap()
+const uint32_t GenoaPhysIos0FabricId = 0x20;
+
+const COMPONENT_LOCATION  GenoaComponentLocation [] = {
+  {0, 0, 0x22, PrimaryFch},     // Physical location, Socket 0, Die 0, Ios2
+  {1, 0, 0x22, SecondaryFch},   // Physical location, Socket 1, Die 0, Ios2
+  {0, 0, 0x22, PrimarySmu},     // Physical location, Socket 0, Die 0, Ios2
+  {1, 0, 0x22, SecondarySmu},   // Physical location, Socket 1, Die 0, Ios2
+};
+
+
+// Stub Functions
+UINT32
+DfXGetNumberOfProcessorsPresent (
+  void
+  )
+{
+  return 1;
+}
+
+UINT32
+DfXGetNumberOfSystemDies (
+  void
+  )
+{
+  return 1;
+}
+
+UINT32 
+DfXGetNumberOfSystemRootBridges (
+  void
+  )
+{
+  return 1;
+}
+
+// Fake Functions
+const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP * DfXGetDeviceMapOnDie (void)
+{
+  const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP *DeviceMap;
+
+  DeviceMap = &GenoaDeviceMap[0];
+  return DeviceMap;
+}
+
+const
+COMPONENT_LOCATION *
+DfXFindComponentLocationMap (
+  uint32_t *Count,
+  uint32_t *PhysIos0FabricId
+  )
+{
+  const COMPONENT_LOCATION *ComponentLocationMap;
+
+  ComponentLocationMap = &GenoaComponentLocation[0];
+  if (Count != NULL) {
+    *Count = sizeof (GenoaComponentLocation) / sizeof (GenoaComponentLocation[0]);
+  }
+  if (PhysIos0FabricId != NULL) {
+    *PhysIos0FabricId = GenoaPhysIos0FabricId;
+  }
+  return ComponentLocationMap;
+}
+
+DF_COMMON_2_REV_XFER_BLOCK DfCmn2RevXfer = {
+  .DfFabricRegisterAccRead                =         NULL,
+  .DfFabricRegisterAccWrite               =         NULL,
+  .DfGetNumberOfProcessorsPresent         =         DfXGetNumberOfProcessorsPresent,
+  .DfGetNumberOfSystemDies                =         DfXGetNumberOfSystemDies,
+  .DfGetNumberOfSystemRootBridges         =         DfXGetNumberOfSystemRootBridges,
+  .DfGetNumberOfRootBridgesOnSocket       =         NULL, 
+  .DfGetNumberOfRootBridgesOnDie          =         NULL,
+  .DfGetDieSystemOffset                   =         NULL,
+  .DfGetDeviceMapOnDie                    =         DfXGetDeviceMapOnDie,// called in DfFindDeviceTypeEntryInMap()
+  .DfGetHostBridgeBusBase                 =         NULL,
+  .DfGetHostBridgeBusLimit                =         NULL,
+  .DfGetPhysRootBridgeNumber              =         NULL,
+  .DfFindComponentLocationMap             =         DfXFindComponentLocationMap,// called in DfGetSystemComponentRootBridgeLocation()
+  .DfBaseFabricTopologyConstructor        =         NULL,
+  .DfBuildDomainInfo                      =         NULL
+};
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_STATUS Status = AMD_UNIT_TEST_PASSED;
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Prerequisite started.", TestName, IterationName);
+  Status = UtSilInit ();
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return AMD_UNIT_TEST_ABORTED;
+  }
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Allocating memory for openSIL.");
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut            = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName                   = UtGetTestName (Ut);
+  const char* IterationName              = UtGetTestIteration (Ut);
+
+  SIL_STATUS           SilStatus;
+  UINT32 NumberOfInstalledProcessors;
+  UINT32 TotalNumberOfDie;
+  UINT32 TotalNumberOfRootBridges;
+  ROOT_BRIDGE_LOCATION SystemFchRootBridgeLocation = {0};
+  ROOT_BRIDGE_LOCATION SystemSmuRootBridgeLocation = {0};
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+
+
+  if (strcmp(IterationName, "SilPass") == 0) {
+    // Arrange
+    NumberOfInstalledProcessors = 1;
+    TotalNumberOfDie = 1;
+    TotalNumberOfRootBridges = 1;
+
+    // Action
+    // Setting up SilGetCommon2RevXferTable to pass. 
+    // Mock 5 times.
+    MockSilGetCommon2RevXferTableManyTimes ((void *)&DfCmn2RevXfer, SilPass, 5);
+
+    SilStatus = DfGetSystemInfo(&NumberOfInstalledProcessors, &TotalNumberOfDie, 
+                                &TotalNumberOfRootBridges,&SystemFchRootBridgeLocation, 
+                                &SystemSmuRootBridgeLocation);
+
+    // Assert
+    if (SilStatus != SilAborted) {
+      Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+            "Did not receive SilAborted", IterationName);
+      UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+    } else {
+      UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+    }
+
+  }else {
+    Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__, "Iteration '%s' is not implemented.", IterationName);
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+  }
+
+  UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Freeing memory allocated to openSIL.");
+  UtSilDeinit ();
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+* main
+* @brief      Stating point for Execution
+*
+* @details    This routine:
+*              - Handles the command line arguments.
+*                example: DfGetSystemInfoUt.exe -o "E:\test" -i
+*                         "ValidateProcessorInfo" -c <Path to Test Config File>
+*              - Declares the unit test framework.
+*              - Run the tests.
+*              - Deallocate the Unit test framework.
+*
+* @param    argc                     Argument count
+* @param    *argv[]                  Argument vector
+*
+* @retval   AMD_UNIT_TEST_PASSED     Function succeeded
+* @retval   NON-ZERO                 Error occurs
+*/
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS     Status;
+  AMD_UNIT_TEST_FRAMEWORK  Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  // Logging the start of the test.
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // Running the test
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}
+ 

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetSystemInfoUt/DfGetSystemInfoUt.h
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetSystemInfoUt/DfGetSystemInfoUt.h
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: MIT */
+/* Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved. */
+/**
+* @file DfGetSystemInfoUt.h
+* @brief
+*
+*/
+#include <xSIM.h>
+#include <DF/Df.h>
+#include <stdlib.h>
+#include <xPRF-api.h>
+#include <UtBaseLib.h>
+#include <UtSilInitLib.h>
+#include <UtLogLib.h>
+#include <Library/UtSilServicesMockLib.h>
+#include <DF/Common/DfCmn2Rev.h>
+#include <DF/Common/BaseFabricTopologyCmn.h>
+#include <DF/Common/SilBaseFabricTopologyLib.h>
+#include <DF\DfX\SilFabricRegistersDfX.h>
+#include <DF/DfX/DfXBaseFabricTopology.h>
+#include <DF\DfX\FabricAcpiDomain\FabricAcpiDomainInfo.h>
+
+// Stub
+UINT32
+DfXGetNumberOfProcessorsPresent (
+  void
+  );
+
+UINT32
+DfXGetNumberOfSystemDies (
+  void
+  );
+
+UINT32 
+DfXGetNumberOfSystemRootBridges (
+  void
+  );
+
+
+// Fake
+const AMD_FABRIC_TOPOLOGY_DIE_DEVICE_MAP* 
+DfXGetDeviceMapOnDie (
+  void
+  );
+
+const COMPONENT_LOCATION* 
+DfXFindComponentLocationMap (
+  uint32_t *Count,
+  uint32_t *PhysIos0FabricId
+  );

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetSystemInfoUt/DfGetSystemInfoUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetSystemInfoUt/DfGetSystemInfoUt.inf
@@ -1,0 +1,38 @@
+# Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+#
+# @file  DfGetSystemInfoUt.inf
+# @brief
+#
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = DfGetSystemInfoUt
+  FILE_GUID      = 3465c34a-541c-4057-a742-d61465ff8176
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h /Dstatic=
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h -Dstatic=
+
+[Sources]
+  DfGetSystemInfoUt.c
+  DfGetSystemInfoUt.h
+  ../../../../../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/DF/Common/BaseFabricTopologyCmn.c
+  
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtIoFakeLib
+  UtSilInitLib
+  UtSilServicesMockLib
+  UtPciStubLib
+ 

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetSystemInfoUt/DfGetSystemInfoUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/Df/Common/DfGetSystemInfoUt/DfGetSystemInfoUt.json
@@ -1,0 +1,6 @@
+[
+  {
+    "Description": " Validate overall system info.",
+    "Iteration"  : "SilPass"
+  }
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindLastPciePortOfThisPcieCUt/FindLastPciePortOfThisPcieCUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindLastPciePortOfThisPcieCUt/FindLastPciePortOfThisPcieCUt.c
@@ -1,0 +1,213 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file FindLastPciePortOfThisPcieCUt.c
+ * @brief
+ *
+ */
+
+#include "FindLastPciePortOfThisPcieCUt.h"
+
+HOST_DEBUG_SERVICE mHostDebugService = NULL;
+
+PCIe_DESCRIPTOR_HEADER* PcieConfigGetPeer(uint32_t Type, PCIe_DESCRIPTOR_HEADER *Descriptor)
+{
+  // return Descriptor;
+  // Create a static PCIe_DESCRIPTOR_HEADER object with minimal values
+  static PCIe_DESCRIPTOR_HEADER StubDescriptor = {
+      .DescriptorFlags = 0, 
+      .Parent = 1,          
+      .Peer = 0,            
+      .Child = 1            
+  };
+
+  // Return a pointer to the static object
+  return &StubDescriptor;
+}
+
+PCIe_DESCRIPTOR_HEADER* PcieConfigGetChild(uint32_t Type, PCIe_DESCRIPTOR_HEADER *Descriptor)
+{
+  // Create a static PCIe_DESCRIPTOR_HEADER object with minimal values
+  static PCIe_DESCRIPTOR_HEADER StubDescriptor = {
+      .DescriptorFlags = 0, 
+      .Parent = 1,          
+      .Peer = 0,            
+      .Child = 1            
+  };
+
+  // Return a pointer to the static object
+  return &StubDescriptor;
+}
+
+PCIe_DESCRIPTOR_HEADER* PcieConfigGetParent (uint32_t Type, PCIe_DESCRIPTOR_HEADER *Descriptor)
+{
+  // Create a static PCIe_DESCRIPTOR_HEADER object with minimal values
+  static PCIe_DESCRIPTOR_HEADER StubDescriptor = {
+      .DescriptorFlags = 0, 
+      .Parent = 1,          
+      .Peer = 0,            
+      .Child = 1            
+  };
+
+  // Return a pointer to the static object
+  return &StubDescriptor;
+}
+
+void
+PcieConfigRunProcForAllWrappersInNbio (
+  uint32_t                      DescriptorFlags,
+  PCIe_RUN_ON_WRAPPER_CALLBACK2 Callback,
+  void                          *Buffer,
+  GNB_HANDLE                    *GnbHandle
+  )
+{
+  return;
+}
+
+void
+PcieConfigRunProcForAllEnginesInWrapper (
+  uint32_t                      DescriptorFlags,
+  PCIe_RUN_ON_ENGINE_CALLBACK2  Callback,
+  void                          *Buffer,
+  PCIe_WRAPPER_CONFIG           *Wrapper
+  )
+{
+  return;
+}
+
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_STATUS Status = AMD_UNIT_TEST_PASSED;
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Prerequisite started.", TestName, IterationName);
+
+  Status = UtSilInit ();
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return AMD_UNIT_TEST_ABORTED;
+  }
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Prerequisite ended.", TestName, IterationName);
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  PCIe_ENGINE_CONFIG  PciePort = {0};
+  HIDE_WRAPPER_INFO   Buffer = {0}; 
+  PCIe_WRAPPER_CONFIG PcieCore = {0};
+  
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+
+  if (strcmp (IterationName, "FindLastPciePortOfThisPcieCore") == 0) {
+    // Arrange
+
+    // Action
+    FindLastPciePortOnPrevPcieCore(&PciePort, &Buffer, &PcieCore);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+      "Iteration '%s' test passed", IterationName);
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+    // Assert
+  } else {
+    Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+      "Iteration '%s' test failed", IterationName);
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+  }
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) CleanUp started.", TestName, IterationName);
+  // Free openSIL allocated memory
+  UtSilDeinit ();
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) CleanUp ended.", TestName, IterationName);
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Stating point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  char *SimpleCharContext = "A simple TestBody context";
+
+  // Logging the start of the test.
+  // Note: Test status at this time is set to "NOT_SET".
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // You can pass into the TestPrerequisite, TestBody, and TestCleanUp context of
+  // your desire
+  UtSetTestContext (&Ut, (AMD_UNIT_TEST_CONTEXT)SimpleCharContext);
+
+  // Running the test
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindLastPciePortOfThisPcieCUt/FindLastPciePortOfThisPcieCUt.h
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindLastPciePortOfThisPcieCUt/FindLastPciePortOfThisPcieCUt.h
@@ -1,0 +1,25 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file  FindLastPciePortOfThisPcieCUt.h
+ * @brief
+ *
+ */
+
+#pragma once
+
+#include <UtBaseLib.h>
+#include <UtSilInitLib.h>
+#include <UtLogLib.h>
+#include <NBIO/GnbDxio.h>
+#include <NBIO/NbioPcieTopologyHelper.h>
+#include <NBIO/Nbio.h>
+#include <NBIO/NbioCommon.h>
+
+#include <xSIM.h>
+#include <CommonLib/SmnAccess.h>
+#include <NbioSmnTable.h>
+#include "GnbRegisters.h"
+#include "NbioData.h"
+#include "NbioPcie.h"
+#include "NbioHidePcieCore.c"

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindLastPciePortOfThisPcieCUt/FindLastPciePortOfThisPcieCUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindLastPciePortOfThisPcieCUt/FindLastPciePortOfThisPcieCUt.inf
@@ -1,0 +1,38 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  FindLastPciePortOfThisPcieCUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = FindLastPciePortOfThisPcieCUt
+  FILE_GUID      = 99345f40-4f48-4014-8be8-368780373c26
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  FindLastPciePortOfThisPcieCUt.c
+  FindLastPciePortOfThisPcieCUt.h
+  ../../../../../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/NBIO/IOD/NbioHidePcieCore.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtIoFakeLib
+  UtSilInitLib
+  UtMmioFakeLib
+  UtSilServicesMockLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindLastPciePortOfThisPcieCUt/FindLastPciePortOfThisPcieCUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindLastPciePortOfThisPcieCUt/FindLastPciePortOfThisPcieCUt.json
@@ -1,0 +1,5 @@
+[
+  {
+    "Iteration": "FindLastPciePortOfThisPcieCore"
+  }
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindLastPciePortOnPrevPcieCUt/FindLastPciePortOnPrevPcieCUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindLastPciePortOnPrevPcieCUt/FindLastPciePortOnPrevPcieCUt.c
@@ -1,0 +1,213 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file FindLastPciePortOnPrevPcieCUt.c
+ * @brief
+ *
+ */
+
+#include "FindLastPciePortOnPrevPcieCUt.h"
+
+HOST_DEBUG_SERVICE mHostDebugService = NULL;
+
+PCIe_DESCRIPTOR_HEADER* PcieConfigGetPeer(uint32_t Type, PCIe_DESCRIPTOR_HEADER *Descriptor)
+{
+  // return Descriptor;
+  // Create a static PCIe_DESCRIPTOR_HEADER object with minimal values
+  static PCIe_DESCRIPTOR_HEADER StubDescriptor = {
+      .DescriptorFlags = 0, 
+      .Parent = 1,          
+      .Peer = 0,            
+      .Child = 1            
+  };
+
+  // Return a pointer to the static object
+  return &StubDescriptor;
+}
+
+PCIe_DESCRIPTOR_HEADER* PcieConfigGetChild(uint32_t Type, PCIe_DESCRIPTOR_HEADER *Descriptor)
+{
+  // Create a static PCIe_DESCRIPTOR_HEADER object with minimal values
+  static PCIe_DESCRIPTOR_HEADER StubDescriptor = {
+      .DescriptorFlags = 0, 
+      .Parent = 1,          
+      .Peer = 0,            
+      .Child = 1            
+  };
+
+  // Return a pointer to the static object
+  return &StubDescriptor;
+}
+
+PCIe_DESCRIPTOR_HEADER* PcieConfigGetParent (uint32_t Type, PCIe_DESCRIPTOR_HEADER *Descriptor)
+{
+  // Create a static PCIe_DESCRIPTOR_HEADER object with minimal values
+  static PCIe_DESCRIPTOR_HEADER StubDescriptor = {
+      .DescriptorFlags = 0, 
+      .Parent = 1,          
+      .Peer = 0,            
+      .Child = 1            
+  };
+
+  // Return a pointer to the static object
+  return &StubDescriptor;
+}
+
+void
+PcieConfigRunProcForAllWrappersInNbio (
+  uint32_t                      DescriptorFlags,
+  PCIe_RUN_ON_WRAPPER_CALLBACK2 Callback,
+  void                          *Buffer,
+  GNB_HANDLE                    *GnbHandle
+  )
+{
+  return;
+}
+
+void
+PcieConfigRunProcForAllEnginesInWrapper (
+  uint32_t                      DescriptorFlags,
+  PCIe_RUN_ON_ENGINE_CALLBACK2  Callback,
+  void                          *Buffer,
+  PCIe_WRAPPER_CONFIG           *Wrapper
+  )
+{
+  return;
+}
+
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_STATUS Status = AMD_UNIT_TEST_PASSED;
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Prerequisite started.", TestName, IterationName);
+
+  Status = UtSilInit ();
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return AMD_UNIT_TEST_ABORTED;
+  }
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Prerequisite ended.", TestName, IterationName);
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  PCIe_ENGINE_CONFIG  PciePort = {0};
+  HIDE_WRAPPER_INFO   Buffer = {0}; 
+  PCIe_WRAPPER_CONFIG PcieCore = {0};
+  
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+
+  if (strcmp (IterationName, "ValidFindLastPciePort") == 0) {
+    // Arrange
+
+    // Action
+    FindLastPciePortOnPrevPcieCore(&PciePort, &Buffer, &PcieCore);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+      "Iteration '%s' test passed", IterationName);
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+    // Assert
+  } else {
+    Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+      "Iteration '%s' test failed", IterationName);
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+  }
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) CleanUp started.", TestName, IterationName);
+  // Free openSIL allocated memory
+  UtSilDeinit ();
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) CleanUp ended.", TestName, IterationName);
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Stating point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  char *SimpleCharContext = "A simple TestBody context";
+
+  // Logging the start of the test.
+  // Note: Test status at this time is set to "NOT_SET".
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // You can pass into the TestPrerequisite, TestBody, and TestCleanUp context of
+  // your desire
+  UtSetTestContext (&Ut, (AMD_UNIT_TEST_CONTEXT)SimpleCharContext);
+
+  // Running the test
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindLastPciePortOnPrevPcieCUt/FindLastPciePortOnPrevPcieCUt.h
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindLastPciePortOnPrevPcieCUt/FindLastPciePortOnPrevPcieCUt.h
@@ -1,0 +1,25 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file  FindLastPciePortOnPrevPcieCUt.h
+ * @brief
+ *
+ */
+
+#pragma once
+
+#include <UtBaseLib.h>
+#include <UtSilInitLib.h>
+#include <UtLogLib.h>
+#include <NBIO/GnbDxio.h>
+#include <NBIO/NbioPcieTopologyHelper.h>
+#include <NBIO/Nbio.h>
+#include <NBIO/NbioCommon.h>
+
+#include <xSIM.h>
+#include <CommonLib/SmnAccess.h>
+#include <NbioSmnTable.h>
+#include "GnbRegisters.h"
+#include "NbioData.h"
+#include "NbioPcie.h"
+#include "NbioHidePcieCore.c"

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindLastPciePortOnPrevPcieCUt/FindLastPciePortOnPrevPcieCUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindLastPciePortOnPrevPcieCUt/FindLastPciePortOnPrevPcieCUt.inf
@@ -1,0 +1,38 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  FindLastPciePortOnPrevPcieCUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = FindLastPciePortOnPrevPcieCUt
+  FILE_GUID      = 7af87f01-c879-4af2-9de0-9939d40c46ed
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  FindLastPciePortOnPrevPcieCUt.c
+  FindLastPciePortOnPrevPcieCUt.h
+  ../../../../../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/NBIO/IOD/NbioHidePcieCore.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtIoFakeLib
+  UtSilInitLib
+  UtMmioFakeLib
+  UtSilServicesMockLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindLastPciePortOnPrevPcieCUt/FindLastPciePortOnPrevPcieCUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindLastPciePortOnPrevPcieCUt/FindLastPciePortOnPrevPcieCUt.json
@@ -1,0 +1,5 @@
+[
+  {
+    "Iteration": "ValidFindLastPciePort"
+  }
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindPcieCoreDescUt/FindPcieCoreDescUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindPcieCoreDescUt/FindPcieCoreDescUt.c
@@ -1,0 +1,239 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file FindPcieCoreDescUt.c
+ * @brief
+ *
+ */
+
+#include "FindPcieCoreDescUt.h"
+
+HOST_DEBUG_SERVICE mHostDebugService = NULL;
+
+PCIe_DESCRIPTOR_HEADER* PcieConfigGetPeer(uint32_t Type, PCIe_DESCRIPTOR_HEADER *Descriptor)
+{
+  // return Descriptor;
+  // Create a static PCIe_DESCRIPTOR_HEADER object with minimal values
+  static PCIe_DESCRIPTOR_HEADER StubDescriptor = {
+      .DescriptorFlags = 0, 
+      .Parent = 1,          
+      .Peer = 0,            
+      .Child = 1            
+  };
+
+  // Return a pointer to the static object
+  return &StubDescriptor;
+}
+
+PCIe_DESCRIPTOR_HEADER* PcieConfigGetChild(uint32_t Type, PCIe_DESCRIPTOR_HEADER *Descriptor)
+{
+  // Create a static PCIe_DESCRIPTOR_HEADER object with minimal values
+  static PCIe_DESCRIPTOR_HEADER StubDescriptor = {
+      .DescriptorFlags = 0, 
+      .Parent = 1,          
+      .Peer = 0,            
+      .Child = 1            
+  };
+
+  // Return a pointer to the static object
+  return &StubDescriptor;
+}
+
+PCIe_DESCRIPTOR_HEADER* PcieConfigGetParent (uint32_t Type, PCIe_DESCRIPTOR_HEADER *Descriptor)
+{
+  // Create a static PCIe_DESCRIPTOR_HEADER object with minimal values
+  static PCIe_DESCRIPTOR_HEADER StubDescriptor = {
+      .DescriptorFlags = 0, 
+      .Parent = 1,          
+      .Peer = 0,            
+      .Child = 1            
+  };
+
+  // Return a pointer to the static object
+  return &StubDescriptor;
+}
+
+void
+PcieConfigRunProcForAllWrappersInNbio (
+  uint32_t                      DescriptorFlags,
+  PCIe_RUN_ON_WRAPPER_CALLBACK2 Callback,
+  void                          *Buffer,
+  GNB_HANDLE                    *GnbHandle
+  )
+{
+  return;
+}
+
+void
+PcieConfigRunProcForAllEnginesInWrapper (
+  uint32_t                      DescriptorFlags,
+  PCIe_RUN_ON_ENGINE_CALLBACK2  Callback,
+  void                          *Buffer,
+  PCIe_WRAPPER_CONFIG           *Wrapper
+  )
+{
+  return;
+}
+
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_STATUS Status = AMD_UNIT_TEST_PASSED;
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Prerequisite started.", TestName, IterationName);
+
+  Status = UtSilInit ();
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return AMD_UNIT_TEST_ABORTED;
+  }
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Prerequisite ended.", TestName, IterationName);
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  PCIe_WRAPPER_CONFIG  PcieCore = {0};
+  HIDE_WRAPPER_INFO    Buffer = {0}; 
+  GNB_HANDLE           GnbHandle = {0};
+  
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+
+  if (strcmp (IterationName, "ValidFindPcieCoreDesc") == 0) {
+    // Arrange
+
+    // Action
+    FindPcieCoreDesc(&PcieCore, &Buffer, &GnbHandle);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+      "Iteration: '%s'  test passed", IterationName);
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+    // Assert
+  } else if(strcmp (IterationName, "HideInfoThisPcieCoreIsNULL") == 0){
+    // Arrange
+    PcieCore.WrapId = 1;
+    Buffer.ThisPcieCore = NULL;
+
+    // Action
+    FindPcieCoreDesc(&PcieCore, &Buffer, &GnbHandle);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+      "Iteration: '%s'  test passed", IterationName);
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+  } else if(strcmp (IterationName, "HideInfoNextPcieCoreIsNULL") == 0){
+    // Arrange
+    PcieCore.WrapId = 1;
+    PCIe_WRAPPER_CONFIG  temp = {0};
+    Buffer.ThisPcieCore = &temp;
+    Buffer.NextPcieCore = NULL;
+
+    // Action
+    FindPcieCoreDesc(&PcieCore, &Buffer, &GnbHandle);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+      "Iteration: '%s'  test passed", IterationName);
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+  }else {
+    Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+      "Iteration '%s' test failed", IterationName);
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+  }
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) CleanUp started.", TestName, IterationName);
+  // Free openSIL allocated memory
+  UtSilDeinit ();
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) CleanUp ended.", TestName, IterationName);
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Stating point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  char *SimpleCharContext = "A simple TestBody context";
+
+  // Logging the start of the test.
+  // Note: Test status at this time is set to "NOT_SET".
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // You can pass into the TestPrerequisite, TestBody, and TestCleanUp context of
+  // your desire
+  UtSetTestContext (&Ut, (AMD_UNIT_TEST_CONTEXT)SimpleCharContext);
+
+  // Running the test
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindPcieCoreDescUt/FindPcieCoreDescUt.h
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindPcieCoreDescUt/FindPcieCoreDescUt.h
@@ -1,0 +1,25 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file  FindPcieCoreDescUt.h
+ * @brief
+ *
+ */
+
+#pragma once
+
+#include <UtBaseLib.h>
+#include <UtSilInitLib.h>
+#include <UtLogLib.h>
+#include <NBIO/GnbDxio.h>
+#include <NBIO/NbioPcieTopologyHelper.h>
+#include <NBIO/Nbio.h>
+#include <NBIO/NbioCommon.h>
+
+#include <xSIM.h>
+#include <CommonLib/SmnAccess.h>
+#include <NbioSmnTable.h>
+#include "GnbRegisters.h"
+#include "NbioData.h"
+#include "NbioPcie.h"
+#include "NbioHidePcieCore.c"

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindPcieCoreDescUt/FindPcieCoreDescUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindPcieCoreDescUt/FindPcieCoreDescUt.inf
@@ -1,0 +1,38 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  FindPcieCoreDescUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = FindPcieCoreDescUt
+  FILE_GUID      = 1153906d-d6f0-4b83-8f37-a0a2a1e04b33
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  FindPcieCoreDescUt.c
+  FindPcieCoreDescUt.h
+  ../../../../../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/NBIO/IOD/NbioHidePcieCore.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtIoFakeLib
+  UtSilInitLib
+  UtMmioFakeLib
+  UtSilServicesMockLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindPcieCoreDescUt/FindPcieCoreDescUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindPcieCoreDescUt/FindPcieCoreDescUt.json
@@ -1,0 +1,11 @@
+[
+  {
+    "Iteration": "ValidFindPcieCoreDesc"
+  },
+  {
+    "Iteration": "HideInfoThisPcieCoreIsNULL"
+  },
+  {
+    "Iteration": "HideInfoNextPcieCoreIsNULL"
+  }
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindPrevPcieCoreUt/FindPrevPcieCoreUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindPrevPcieCoreUt/FindPrevPcieCoreUt.c
@@ -1,0 +1,367 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file FindPrevPcieCoreUt.c
+ * @brief
+ *
+ */
+
+#include "FindPrevPcieCoreUt.h"
+
+HOST_DEBUG_SERVICE mHostDebugService = NULL;
+
+PCIe_DESCRIPTOR_HEADER* PcieConfigGetPeer(uint32_t Type, PCIe_DESCRIPTOR_HEADER *Descriptor)
+{
+  // Create a static or dummy PCIe_DESCRIPTOR_HEADER object with minimal values
+  static PCIe_DESCRIPTOR_HEADER StubDescriptor = {
+      .DescriptorFlags = 1, 
+      .Parent = 1,          
+      .Peer = 1,            
+      .Child = 1            
+  };
+
+  // Return a pointer to the static object
+  return &StubDescriptor;
+}
+
+void
+PcieConfigRunProcForAllWrappersInNbio (
+  uint32_t                      DescriptorFlags,
+  PCIe_RUN_ON_WRAPPER_CALLBACK2 Callback,
+  void                          *Buffer,
+  GNB_HANDLE                    *GnbHandle
+  )
+{
+  return;
+}
+
+void
+PcieConfigRunProcForAllEnginesInWrapper (
+  uint32_t                      DescriptorFlags,
+  PCIe_RUN_ON_ENGINE_CALLBACK2  Callback,
+  void                          *Buffer,
+  PCIe_WRAPPER_CONFIG           *Wrapper
+  )
+{
+  return;
+}
+
+// MOCK CONTROL VARIABLES (static to limit scope)
+static PCIe_SILICON_CONFIG *mock_silicon_parent = NULL;
+static PCIe_PLATFORM_CONFIG *mock_platform_parent = NULL;
+static PCIe_SILICON_CONFIG *mock_silicon_child = NULL;
+static PCIe_WRAPPER_CONFIG *mock_first_wrapper = NULL;
+
+// MOCKED FUNCTIONS (static to limit scope)
+PCIe_DESCRIPTOR_HEADER* PcieConfigGetParent(uint32_t Type, PCIe_DESCRIPTOR_HEADER *Descriptor) {
+  if (Type == DESCRIPTOR_SILICON) {
+    return (PCIe_DESCRIPTOR_HEADER*)mock_silicon_parent;
+  } else if (Type == DESCRIPTOR_PLATFORM) {
+    return (PCIe_DESCRIPTOR_HEADER*)mock_platform_parent;
+  }
+  return NULL;
+}
+
+PCIe_DESCRIPTOR_HEADER* PcieConfigGetChild(uint32_t Type, PCIe_DESCRIPTOR_HEADER *Descriptor) {
+  if (Type == DESCRIPTOR_SILICON) {
+    return (PCIe_DESCRIPTOR_HEADER*)mock_silicon_child;
+  } else if (Type == DESCRIPTOR_ALL_WRAPPERS) {
+    return (PCIe_DESCRIPTOR_HEADER*)mock_first_wrapper;
+  }
+  return NULL;
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_STATUS Status = AMD_UNIT_TEST_PASSED;
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Prerequisite started.", TestName, IterationName);
+
+  Status = UtSilInit ();
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return AMD_UNIT_TEST_ABORTED;
+  }
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Prerequisite ended.", TestName, IterationName);
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+  
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+    
+  // Test Case 1: Early return when InstanceID is 0
+  if(strcmp (IterationName, "InvalidInstanceID") == 0){
+
+  // Arrange
+  HIDE_WRAPPER_INFO HideInfo = {0};
+  PCIe_WRAPPER_CONFIG PcieCore;
+  PCIe_SILICON_CONFIG Silicon = { .InstanceId = 0 };
+
+  mock_silicon_parent = &Silicon;  // Returned by PcieConfigGetParent(DESCRIPTOR_SILICON)
+  mock_platform_parent = NULL;     // Not used in this test case
+
+  // Act
+  FindPrevPcieCore(&HideInfo, &PcieCore);
+
+  // Assert: Function should exit early; HideInfo.PrevPcieCore remains NULL
+  if (HideInfo.PrevPcieCore == NULL) {
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Iteration '%s' test passed", IterationName);
+    UtSetTestStatus(Ut, AMD_UNIT_TEST_PASSED);
+  } else {
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Iteration '%s' test failed", IterationName);
+    UtSetTestStatus(Ut, AMD_UNIT_TEST_FAILED);
+  }
+
+  } 
+  // Test Case 2: Find previous silicon and its last wrapper
+  else if(strcmp (IterationName, "FindPrevSiliconAndLastWrapper") == 0){
+
+  // Arrange
+  HIDE_WRAPPER_INFO HideInfo = {0};
+  PCIe_WRAPPER_CONFIG PcieCore;
+  PCIe_SILICON_CONFIG Silicon = { .InstanceId = 1 };
+  PCIe_PLATFORM_CONFIG Pcie;
+  PCIe_SILICON_CONFIG PrevSilicon = { 
+    .InstanceId = 0,
+    .Header = { .Peer = 0 }                 // Terminate topology list
+  };
+  PCIe_WRAPPER_CONFIG Wrappers[2] = {
+    { .Header.DescriptorFlags = 0 },        // First wrapper
+    { .Header.DescriptorFlags = DESCRIPTOR_TERMINATE_LIST }  // Last wrapper
+  };
+
+  // Link wrappers
+  Wrappers[0].Header.Peer = (uint16_t)((uint8_t*)&Wrappers[1] - (uint8_t*)&Wrappers[0]);
+
+  mock_silicon_parent = &Silicon;     // PcieCore's parent silicon
+  mock_platform_parent = &Pcie;       // Silicon's parent platform
+  mock_silicon_child = &PrevSilicon;  // Platform's child silicon
+  mock_first_wrapper = &Wrappers[0];  // PrevSilicon's first wrapper
+
+  // Act
+  FindPrevPcieCore(&HideInfo, &PcieCore);
+
+  // Assert: Last wrapper (Wrappers[1]) should be saved in HideInfo
+  if (HideInfo.PrevPcieCore == &Wrappers[1]) {
+    UtSetTestStatus(Ut, AMD_UNIT_TEST_PASSED);
+  } else {
+    UtSetTestStatus(Ut, AMD_UNIT_TEST_FAILED);
+  }
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Iteration '%s' test passed", IterationName);
+  UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+}
+  // Test Case 3: Traverse multiple silicons to find the matching one
+  else if(strcmp (IterationName, "TraverseMultipleSilicons") == 0){
+
+  // Arrange
+  HIDE_WRAPPER_INFO HideInfo = {0};
+  PCIe_WRAPPER_CONFIG PcieCore;
+  PCIe_SILICON_CONFIG Silicon = { .InstanceId = 3 };  
+  PCIe_PLATFORM_CONFIG Pcie;
+
+  // Create Silicons: InstanceId 0 → 1 → 2 (target)
+  PCIe_SILICON_CONFIG Silicons[3] = {
+    [0] = {
+      .InstanceId = 0,
+      .Header = {
+        .Peer = sizeof(PCIe_SILICON_CONFIG),           
+        .DescriptorFlags = 0                           
+      }
+    },
+    [1] = {
+      .InstanceId = 1,
+      .Header = {
+        .Peer = sizeof(PCIe_SILICON_CONFIG),           
+        .DescriptorFlags = 0                           
+      }
+    },
+    [2] = {
+      .InstanceId = 2,                                 
+      .Header = {
+        .Peer = 0,                                     
+        .DescriptorFlags = DESCRIPTOR_TERMINATE_TOPOLOGY  
+      }
+    }
+  };
+
+  // Wrapper under Silicon[2]
+  PCIe_WRAPPER_CONFIG Wrapper = { 
+    .Header.DescriptorFlags = DESCRIPTOR_TERMINATE_LIST 
+  };
+
+  // Mock Setup
+  mock_silicon_parent = &Silicon;     
+  mock_platform_parent = &Pcie;       
+  mock_silicon_child = &Silicons[0];  
+  mock_first_wrapper = &Wrapper;      
+
+  // Act
+  FindPrevPcieCore(&HideInfo, &PcieCore);
+
+  // Assert: Loop calls PcieConfigGetNextTopologyDescriptor twice before breaking
+  if (HideInfo.PrevPcieCore == &Wrapper) {
+    // Verify the state of mock objects
+    assert(mock_silicon_parent == &Silicon);
+    assert(mock_platform_parent == &Pcie);
+    assert(mock_silicon_child == &Silicons[0]);
+    assert(mock_first_wrapper == &Wrapper);
+    UtSetTestStatus(Ut, AMD_UNIT_TEST_PASSED);
+  } else {
+    UtSetTestStatus(Ut, AMD_UNIT_TEST_FAILED);
+  }
+
+}
+  // Test Case 4: Previous silicon not found (no silicon with InstanceID - 1)
+  else if(strcmp (IterationName, "PrevSiliconNotFound") == 0){
+
+  // Arrange
+  HIDE_WRAPPER_INFO HideInfo = {0};
+  PCIe_WRAPPER_CONFIG PcieCore;
+  PCIe_SILICON_CONFIG Silicon = { .InstanceId = 1 };  
+  PCIe_PLATFORM_CONFIG Pcie;
+
+  // Create Silicons: InstanceId 2 → 3 (no InstanceId = 0)
+  PCIe_SILICON_CONFIG Silicons[2] = {
+    [0] = {
+      .InstanceId = 2,
+      .Header = {
+        .Peer = sizeof(PCIe_SILICON_CONFIG),           
+        .DescriptorFlags = 0                           
+      }
+    },
+    [1] = {
+      .InstanceId = 3,
+      .Header = {
+        .Peer = 0,                                       
+        .DescriptorFlags = DESCRIPTOR_TERMINATE_TOPOLOGY 
+      }
+    }
+  };
+
+  // Mock Setup
+  mock_silicon_parent = &Silicon;     
+  mock_platform_parent = &Pcie;       
+  mock_silicon_child = &Silicons[0];  
+
+  // Act
+  FindPrevPcieCore(&HideInfo, &PcieCore);
+
+  // Assert: PrevSilicon becomes NULL → Function returns early
+  if (HideInfo.PrevPcieCore == NULL) {
+    // Verify the state of mock objects
+    assert(mock_silicon_parent == &Silicon);
+    assert(mock_platform_parent == &Pcie);
+    assert(mock_silicon_child == &Silicons[0]);
+    assert(mock_first_wrapper == NULL);
+    UtSetTestStatus(Ut, AMD_UNIT_TEST_PASSED);
+  } else {
+    UtSetTestStatus(Ut, AMD_UNIT_TEST_FAILED);
+  }
+
+} else {
+  Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+      "Unknown test iteration '%s'", IterationName);
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+  }
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) CleanUp started.", TestName, IterationName);
+  // Free openSIL allocated memory
+  UtSilDeinit ();
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) CleanUp ended.", TestName, IterationName);
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Stating point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  char *SimpleCharContext = "A simple TestBody context";
+
+  // Logging the start of the test.
+  // Note: Test status at this time is set to "NOT_SET".
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // You can pass into the TestPrerequisite, TestBody, and TestCleanUp context of
+  // your desire
+  UtSetTestContext (&Ut, (AMD_UNIT_TEST_CONTEXT)SimpleCharContext);
+
+  // Running the test
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindPrevPcieCoreUt/FindPrevPcieCoreUt.h
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindPrevPcieCoreUt/FindPrevPcieCoreUt.h
@@ -1,0 +1,33 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file  FindPrevPcieCoreUt.h
+ * @brief
+ *
+ */
+
+#pragma once
+
+#include <UtBaseLib.h>
+#include <UtSilInitLib.h>
+#include <UtLogLib.h>
+#include <NBIO/GnbDxio.h>
+#include <NBIO/NbioPcieTopologyHelper.h>
+#include <NBIO/Nbio.h>
+#include <NBIO/NbioCommon.h>
+
+#include <xSIM.h>
+#include <CommonLib/SmnAccess.h>
+#include <NbioSmnTable.h>
+#include "GnbRegisters.h"
+#include "NbioData.h"
+#include "NbioPcie.h"
+#include "NbioHidePcieCore.c"
+
+#include <Uefi.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <Io.h>
+

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindPrevPcieCoreUt/FindPrevPcieCoreUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindPrevPcieCoreUt/FindPrevPcieCoreUt.inf
@@ -1,0 +1,38 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  FindPrevPcieCoreUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = FindPrevPcieCoreUt
+  FILE_GUID      = 87ef1eb3-9f26-4dd2-9624-5d29bb9f5be3
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  FindPrevPcieCoreUt.c
+  FindPrevPcieCoreUt.h
+  ../../../../../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/NBIO/IOD/NbioHidePcieCore.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtIoFakeLib
+  UtSilInitLib
+  UtMmioFakeLib
+  UtSilServicesMockLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindPrevPcieCoreUt/FindPrevPcieCoreUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/FindPrevPcieCoreUt/FindPrevPcieCoreUt.json
@@ -1,0 +1,14 @@
+[
+  {
+    "Iteration": "InvalidInstanceID"
+  },
+  {
+    "Iteration": "FindPrevSiliconAndLastWrapper"
+  },
+  {
+    "Iteration": "TraverseMultipleSilicons"
+  },
+  {
+    "Iteration": "PrevSiliconNotFound"
+  }
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/InitNbioConfigDataUt/InitNbioConfigDataUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/InitNbioConfigDataUt/InitNbioConfigDataUt.c
@@ -1,0 +1,158 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file InitNbioConfigDataUt.c
+ * @brief
+ *
+ */
+
+#include "InitNbioConfigDataUt.h"
+
+HOST_DEBUG_SERVICE mHostDebugService = NULL;
+
+NBIOCLASS_DATA mNbioIpBlockData;
+NBIO_CONFIG_DATA mNbioConfigData;
+
+// Mock
+uint32_t
+xUSLSmnRead (
+  uint32_t SegmentNumber,
+  uint32_t IohcBus,
+  uint32_t SmnAddress
+  )
+{
+  return (uint32_t)(0xAA << 24);
+}
+
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_STATUS Status = AMD_UNIT_TEST_PASSED;
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Prerequisite started.", TestName, IterationName);
+
+  Status = UtSilInit ();
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return AMD_UNIT_TEST_ABORTED;
+  }
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Prerequisite ended.", TestName, IterationName);
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  if (strcmp (IterationName, "InitDataSuccess") == 0) {
+      // Arrange
+      mNbioIpBlockData.NbioConfigData = &mNbioConfigData;
+      mNbioConfigData.OpnSpare = 0;  // Initialize to known value
+
+      // Action
+      InitNbioConfigData();
+
+      // Assert
+      if (mNbioConfigData.OpnSpare == 0xAA) {  // Should match the mock xUSLSmnRead return value
+        Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+          "Iteration '%s' test passed", IterationName);
+        UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+      } else {
+        Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+          "OpnSpare value mismatch. Expected: 0xAA, Got: 0x%x", mNbioConfigData.OpnSpare);
+        UtSetTestStatus (Ut, AMD_UNIT_TEST_FAILED);
+      }
+  }else {
+    Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+      "Iteration '%s' test failed", IterationName);
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+  }
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) CleanUp started.", TestName, IterationName);
+  // Free openSIL allocated memory
+  UtSilDeinit ();
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) CleanUp ended.", TestName, IterationName);
+  return AMD_UNIT_TEST_PASSED;
+}
+
+
+/**
+ * main
+ * @brief      Stating point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+
+  // Logging the start of the test.
+  // Note: Test status at this time is set to "NOT_SET".
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // Running the test
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/InitNbioConfigDataUt/InitNbioConfigDataUt.h
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/InitNbioConfigDataUt/InitNbioConfigDataUt.h
@@ -1,0 +1,18 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file  InitNbioConfigDataUt.h
+ * @brief
+ *
+ */
+
+#pragma once
+
+#include "NbioData.h"
+
+#include <UtBaseLib.h>
+#include <UtSilInitLib.h>
+#include <UtLogLib.h>
+#include <xSIM.h>
+#include <CommonLib/SmnAccess.h>
+

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/InitNbioConfigDataUt/InitNbioConfigDataUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/InitNbioConfigDataUt/InitNbioConfigDataUt.inf
@@ -1,0 +1,38 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  InitNbioConfigDataUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = InitNbioConfigDataUt
+  FILE_GUID      = 5d5d954d-8441-45df-88a9-95c8fb7d0e2f
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  InitNbioConfigDataUt.c
+  InitNbioConfigDataUt.h
+  ../../../../../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/NBIO/IOD/NbioData.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtIoFakeLib
+  UtSilInitLib
+  UtMmioFakeLib
+  UtSilServicesMockLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/InitNbioConfigDataUt/InitNbioConfigDataUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/InitNbioConfigDataUt/InitNbioConfigDataUt.json
@@ -1,0 +1,5 @@
+[
+  {
+    "Iteration": "InitDataSuccess"
+  }
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/IsSteppingAxUt/IsSteppingAxUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/IsSteppingAxUt/IsSteppingAxUt.c
@@ -1,0 +1,277 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file IsSteppingAxUt.c
+ * @brief
+ *
+ */
+
+#include "IsSteppingAxUt.h"
+
+HOST_DEBUG_SERVICE mHostDebugService = NULL;
+
+// Mock data
+#define AMD_REV_F19_GENOA_A0    0x0001u
+#define AMD_REV_F19_GENOA_A1    0x0002u
+#define AMD_REV_F19_GENOA_AX    (AMD_REV_F19_GENOA_A0 | AMD_REV_F19_GENOA_A1)
+
+const SMN_TABLE NbioPprInitValues[] = {0};
+const SMN_TABLE GnbEarlyInitTableCommon[] = {0};
+const SMN_TABLE GnbnBifInitTable[] = {0};
+const SMN_TABLE GnbOncePerSocketInitMP[] = {0};
+const SMN_TABLE GnbSdpMuxInitTableCommon[] = {0};
+NBIOCLASS_DATA  mNbioIpBlockData = {0};
+NBIO_CONFIG_DATA mNbioConfigDataDflts = {0};
+
+// Mock data
+static SIL_STATUS     MockReturnStatus;
+static SOC_LOGICAL_ID MockLogicalId;
+
+
+// Mock
+SIL_STATUS 
+GetSocLogicalIdOnCurrentCore (
+  SOC_LOGICAL_ID *LogicalId
+  )
+{
+  *LogicalId = MockLogicalId;
+  return MockReturnStatus;
+}
+
+// Stub
+void
+xUSLSmnReadModifyWrite (
+  uint32_t    SegmentNumber,
+  uint32_t    IohcBus,
+  uint32_t    SmnAddress,
+  uint32_t    AndMask,
+  uint32_t    OrMask
+  )
+{
+  return;
+}
+
+GNB_HANDLE* GetGnbHandle (void)
+{
+  static GNB_HANDLE  GnbHandle = {0};
+  return &GnbHandle;
+}
+
+void
+xUSLSmnWrite (
+  uint32_t SegmentNumber,
+  uint32_t IohcBus,
+  uint32_t SmnAddress,
+  uint32_t Value
+)
+{
+  return;
+}
+
+uint32_t
+xUSLSmnRead (
+  uint32_t SegmentNumber,
+  uint32_t IohcBus,
+  uint32_t SmnAddress
+  )
+{
+  return 0;
+}
+
+SIL_STATUS ProgramNbioSmnTable (
+        GNB_HANDLE             *GnbHandle,
+        const SMN_TABLE        *Table,
+        uint32_t               Modifier,
+        uint32_t               Property
+  )
+{
+  return SilPass;
+}
+
+void
+NonPciBarInit (
+         GNB_HANDLE   *GnbHandle,
+         uint32_t     MmioBarLow,
+         uint32_t     MmioBarHigh,
+         uint32_t     MemorySize,
+         bool         Enable,
+         bool         LockSettings,
+         bool         Above4G
+  )
+{
+  return;
+}
+
+PCIe_DESCRIPTOR_HEADER* 
+PcieConfigGetChild(
+  uint32_t Type, 
+  PCIe_DESCRIPTOR_HEADER *Descriptor
+  )
+{
+    return Descriptor;
+}
+
+SIL_STATUS
+PcieComplexHidePcieCore (
+        GNB_HANDLE     *GnbHandle,
+        uint32_t       PcieCoreNum
+  )
+{
+  return SilPass;
+}
+
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_STATUS Status = AMD_UNIT_TEST_PASSED;
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Prerequisite started.", TestName, IterationName);
+
+  Status = UtSilInit ();
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return AMD_UNIT_TEST_ABORTED;
+  }
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Prerequisite ended.", TestName, IterationName);
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+  
+  if (strcmp (IterationName, "SilPass") == 0) {
+    // Arrange
+    MockReturnStatus = SilPass;  
+    MockLogicalId.Family = 1;
+    MockLogicalId.Revision = 1;
+
+    // Action
+    bool valid = IsSteppingAx();
+
+    // Assert
+    if(valid == true){
+      Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+        "Iteration '%s' test passed", IterationName);
+      UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+    }else{
+      Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+        "Iteration '%s' test failed", IterationName);
+      UtSetTestStatus (Ut, AMD_UNIT_TEST_FAILED);
+    }
+
+  } else if (strcmp (IterationName, "SilInvalidParameter") == 0) {
+    // Arrange
+    MockReturnStatus = SilInvalidParameter;
+
+    // Action
+    bool valid = IsSteppingAx();
+
+    // Assert
+    if(valid == false){
+      Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+        "Iteration '%s' test passed", IterationName);
+      UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+    }else{
+      Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+        "Iteration '%s' test failed", IterationName);
+      UtSetTestStatus (Ut, AMD_UNIT_TEST_FAILED);
+    }
+  }else {
+    Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+      "Iteration '%s' test failed", IterationName);
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+  }
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) CleanUp started.", TestName, IterationName);
+  // Free openSIL allocated memory
+  UtSilDeinit ();
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) CleanUp ended.", TestName, IterationName);
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Stating point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  char *SimpleCharContext = "A simple TestBody context";
+
+  // Logging the start of the test.
+  // Note: Test status at this time is set to "NOT_SET".
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // You can pass into the TestPrerequisite, TestBody, and TestCleanUp context of
+  // your desire
+  UtSetTestContext (&Ut, (AMD_UNIT_TEST_CONTEXT)SimpleCharContext);
+
+  // Running the test
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/IsSteppingAxUt/IsSteppingAxUt.h
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/IsSteppingAxUt/IsSteppingAxUt.h
@@ -1,0 +1,33 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file  IsSteppingAxUt.h
+ * @brief
+ *
+ */
+
+#pragma once
+
+#include <xSIM.h>
+#include <CommonLib/SmnAccess.h>
+#include <NbioSmnTable.h>
+#include "GnbRegisters.h"
+#include "NbioData.h"
+#include <NBIO/NbioCommon.h>
+#include <NBIO/GnbDxio.h>
+#include <NBIO/NbioPcieTopologyHelper.h>
+#include <NBIO/IOD/include/GlobalRegB0.h>
+#include <NBIO/IOD/include/SyshubmmReg.h>
+#include <NbioPcie.h>
+#include <SilSocLogicalId.h>
+#include <NBIO/IOD/NbioBaseInitGenoa.c>
+
+#include <UtBaseLib.h>
+#include <UtSilInitLib.h>
+#include <UtLogLib.h>
+#include <NBIO/Nbio.h>
+#include "NbioDefaults.h"
+#include "NbioIohcTbl.h"
+#include "NbioIoapicTbl.h"
+#include "NbioNbifTbl.h"
+#include "NbioWorkaroundTbl.h"

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/IsSteppingAxUt/IsSteppingAxUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/IsSteppingAxUt/IsSteppingAxUt.inf
@@ -1,0 +1,38 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  IsSteppingAxUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = IsSteppingAxUt
+  FILE_GUID      = 489d8ac7-3725-4ea2-8246-b9e33fdb3e5f
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  IsSteppingAxUt.c
+  IsSteppingAxUt.h
+  ../../../../../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/NBIO/IOD/NbioBaseInitGenoa.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtIoFakeLib
+  UtSilInitLib
+  UtMmioFakeLib
+  UtSilServicesMockLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/IsSteppingAxUt/IsSteppingAxUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/IsSteppingAxUt/IsSteppingAxUt.json
@@ -1,0 +1,8 @@
+[
+  {
+    "Iteration": "SilPass"
+  },
+  {
+    "Iteration": "SilInvalidParameter"
+  }
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/PcieConfigAttachDescriptorsUt/PcieConfigAttachDescriptorsUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/PcieConfigAttachDescriptorsUt/PcieConfigAttachDescriptorsUt.c
@@ -1,0 +1,221 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file PcieConfigAttachDescriptorsUt.c
+ * @brief
+ *
+ */
+
+#include "PcieConfigAttachDescriptorsUt.h"
+
+HOST_DEBUG_SERVICE mHostDebugService = NULL;
+
+PCIe_DESCRIPTOR_HEADER* PcieConfigGetPeer(uint32_t Type, PCIe_DESCRIPTOR_HEADER *Descriptor)
+{
+  // return Descriptor;
+  // Create a static or dummy PCIe_DESCRIPTOR_HEADER object with minimal values
+  static PCIe_DESCRIPTOR_HEADER StubDescriptor = {
+      .DescriptorFlags = 0, 
+      .Parent = 1,          
+      .Peer = 0,            
+      .Child = 1            
+  };
+
+  // Return a pointer to the static object
+  return &StubDescriptor;
+}
+
+PCIe_DESCRIPTOR_HEADER* PcieConfigGetChild(uint32_t Type, PCIe_DESCRIPTOR_HEADER *Descriptor)
+{
+  // Create a static PCIe_DESCRIPTOR_HEADER object with minimal values
+  static PCIe_DESCRIPTOR_HEADER StubDescriptor = {
+      .DescriptorFlags = 0, 
+      .Parent = 1,          
+      .Peer = 0,            
+      .Child = 1            
+  };
+
+  // Return a pointer to the static object
+  return &StubDescriptor;
+}
+
+PCIe_DESCRIPTOR_HEADER* PcieConfigGetParent (uint32_t Type, PCIe_DESCRIPTOR_HEADER *Descriptor)
+{
+  // Create a static PCIe_DESCRIPTOR_HEADER object with minimal values
+  static PCIe_DESCRIPTOR_HEADER StubDescriptor = {
+      .DescriptorFlags = 0, 
+      .Parent = 1,          
+      .Peer = 0,            
+      .Child = 1            
+  };
+
+  // Return a pointer to the static object
+  return &StubDescriptor;
+}
+
+void
+PcieConfigRunProcForAllWrappersInNbio (
+  uint32_t                      DescriptorFlags,
+  PCIe_RUN_ON_WRAPPER_CALLBACK2 Callback,
+  void                          *Buffer,
+  GNB_HANDLE                    *GnbHandle
+  )
+{
+  return;
+}
+
+void
+PcieConfigRunProcForAllEnginesInWrapper (
+  uint32_t                      DescriptorFlags,
+  PCIe_RUN_ON_ENGINE_CALLBACK2  Callback,
+  void                          *Buffer,
+  PCIe_WRAPPER_CONFIG           *Wrapper
+  )
+{
+  return;
+}
+
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_STATUS Status = AMD_UNIT_TEST_PASSED;
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Prerequisite started.", TestName, IterationName);
+
+  Status = UtSilInit ();
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return AMD_UNIT_TEST_ABORTED;
+  }
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Prerequisite ended.", TestName, IterationName);
+  return AMD_UNIT_TEST_PASSED;
+}
+
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  UINT32 Type;
+  PCIe_DESCRIPTOR_HEADER Base = {0};
+  PCIe_DESCRIPTOR_HEADER New  = {0};
+
+  void
+PcieConfigAttachDescriptors (
+      uint32_t                       Type,
+      PCIe_DESCRIPTOR_HEADER         *Base,
+      PCIe_DESCRIPTOR_HEADER         *New
+  );
+  
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+
+  if (strcmp (IterationName, "ValidDescriptorRemoved") == 0) {
+    // Arrange
+    Type  = 1;
+
+    // Action
+    PcieConfigAttachDescriptors(Type, &Base, &New);
+
+    Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+      "ValidDescriptorRemoved test passed", IterationName);
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_PASSED);
+
+    // Assert
+  } else {
+    Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+      "Iteration '%s' test failed", IterationName);
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+  }
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) CleanUp started.", TestName, IterationName);
+  // Free openSIL allocated memory
+  UtSilDeinit ();
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) CleanUp ended.", TestName, IterationName);
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Stating point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  char *SimpleCharContext = "A simple TestBody context";
+
+  // Logging the start of the test.
+  // Note: Test status at this time is set to "NOT_SET".
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // You can pass into the TestPrerequisite, TestBody, and TestCleanUp context of
+  // your desire
+  UtSetTestContext (&Ut, (AMD_UNIT_TEST_CONTEXT)SimpleCharContext);
+
+  // Running the test
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/PcieConfigAttachDescriptorsUt/PcieConfigAttachDescriptorsUt.h
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/PcieConfigAttachDescriptorsUt/PcieConfigAttachDescriptorsUt.h
@@ -1,0 +1,26 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file  PcieConfigAttachDescriptorsUt.h
+ * @brief
+ *
+ */
+
+#pragma once
+
+#include <UtBaseLib.h>
+#include <UtSilInitLib.h>
+#include <UtLogLib.h>
+#include <NBIO/GnbDxio.h>
+#include <NBIO/NbioPcieTopologyHelper.h>
+#include <NBIO/Nbio.h>
+#include <NBIO/NbioCommon.h>
+
+#include <xSIM.h>
+#include <CommonLib/SmnAccess.h>
+#include <NbioSmnTable.h>
+#include "GnbRegisters.h"
+#include "NbioData.h"
+#include "NbioPcie.h"
+#include "NbioHidePcieCore.c"
+

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/PcieConfigAttachDescriptorsUt/PcieConfigAttachDescriptorsUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/PcieConfigAttachDescriptorsUt/PcieConfigAttachDescriptorsUt.inf
@@ -1,0 +1,38 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  PcieConfigAttachDescriptorsUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = PcieConfigAttachDescriptorsUt
+  FILE_GUID      = 3e26c733-64bb-47fb-abea-68eaa6b9a2b5
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  PcieConfigAttachDescriptorsUt.c
+  PcieConfigAttachDescriptorsUt.h
+  ../../../../../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/NBIO/IOD/NbioHidePcieCore.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtIoFakeLib
+  UtSilInitLib
+  UtMmioFakeLib
+  UtSilServicesMockLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/PcieConfigAttachDescriptorsUt/PcieConfigAttachDescriptorsUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/PcieConfigAttachDescriptorsUt/PcieConfigAttachDescriptorsUt.json
@@ -1,0 +1,5 @@
+[
+  {
+    "Iteration": "ValidDescriptorRemoved"
+  }
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/PcieEnumerateAndHarvestWrUt/PcieEnumerateAndHarvestWrUt.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/PcieEnumerateAndHarvestWrUt/PcieEnumerateAndHarvestWrUt.c
@@ -1,0 +1,305 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file PcieEnumerateAndHarvestWrUt.c
+ * @brief
+ *
+ */
+
+#include "PcieEnumerateAndHarvestWrUt.h"
+
+HOST_DEBUG_SERVICE mHostDebugService = NULL;
+
+#define PcieLibGetNextDescriptor(Descriptor) ((Descriptor == NULL) ? NULL : ((Descriptor->Header.DescriptorFlags & DESCRIPTOR_TERMINATE_LIST) != 0) ? NULL : (Descriptor + 1))
+
+const SMN_TABLE NbioPprInitValues[] = {0};
+const SMN_TABLE GnbEarlyInitTableCommon[] = {0};
+const SMN_TABLE GnbnBifInitTable[] = {0};
+const SMN_TABLE GnbOncePerSocketInitMP[] = {0};
+const SMN_TABLE GnbSdpMuxInitTableCommon[] = {0};
+NBIOCLASS_DATA  mNbioIpBlockData = {0};
+
+// Mock data
+static PCIe_COMPLEX_CONFIG mockComplex;
+static PCIe_SILICON_CONFIG mockSilicon;
+static PCIe_WRAPPER_CONFIG mockWrapper;
+static uint32_t mockFuseData;
+static bool mockIsSteppingAx = false;
+
+// Mock functions for testing function PcieEnumerateAndHarvestWrappers()
+bool 
+IsSteppingAx (
+  void
+  )
+{
+  return mockIsSteppingAx;
+}
+
+// control the mock version of IsSteppingAx 
+void 
+SetIsSteppingAx (
+  IN bool Value
+  )
+{
+  mockIsSteppingAx = Value;
+}
+
+
+PCIe_DESCRIPTOR_HEADER* 
+PcieConfigGetChild (
+  IN uint32_t Type,
+  IN PCIe_DESCRIPTOR_HEADER* Descriptor
+  )
+{
+  if (Type == DESCRIPTOR_COMPLEX) {
+    return &mockComplex.Header;
+  }
+  if (Type == DESCRIPTOR_SILICON) {
+    return &mockSilicon.Header;
+  }
+  if (Type == DESCRIPTOR_ALL_WRAPPERS) {
+    return &mockWrapper.Header;
+  }
+  return NULL;
+}
+
+uint32_t 
+xUSLSmnRead (
+  IN uint32_t Segment,
+  IN uint32_t Bus,
+  IN uint32_t Address
+  )
+{
+  return mockFuseData;
+}
+
+SIL_STATUS 
+PcieComplexHidePcieCore (
+  IN GNB_HANDLE* GnbHandle,
+  IN uint32_t PcieCoreNum
+  )
+{
+  return SilPass;
+}
+
+//Stub and nock functions in the same file
+
+void
+xUSLSmnWrite (
+  uint32_t SegmentNumber,
+  uint32_t IohcBus,
+  uint32_t SmnAddress,
+  uint32_t Value
+)
+{
+  return;
+}
+
+void
+xUSLSmnReadModifyWrite (
+  uint32_t    SegmentNumber,
+  uint32_t    IohcBus,
+  uint32_t    SmnAddress,
+  uint32_t    AndMask,
+  uint32_t    OrMask
+  )
+{
+  return;
+}
+
+SIL_STATUS 
+GetSocLogicalIdOnCurrentCore (
+  SOC_LOGICAL_ID *LogicalId
+  )
+{
+  return SilPass;
+}
+
+SIL_STATUS ProgramNbioSmnTable (
+        GNB_HANDLE             *GnbHandle,
+        const SMN_TABLE        *Table,
+        uint32_t               Modifier,
+        uint32_t               Property
+  )
+{
+  return SilPass;
+}
+
+GNB_HANDLE* GetGnbHandle (void)
+{
+  static GNB_HANDLE  GnbHandle = {0};
+  return &GnbHandle;
+}
+
+void
+NonPciBarInit (
+         GNB_HANDLE   *GnbHandle,
+         uint32_t     MmioBarLow,
+         uint32_t     MmioBarHigh,
+         uint32_t     MemorySize,
+         bool         Enable,
+         bool         LockSettings,
+         bool         Above4G
+  )
+{
+  return;
+}
+
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestPrerequisite (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_STATUS Status = AMD_UNIT_TEST_PASSED;
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Prerequisite started.", TestName, IterationName);
+
+  Status = UtSilInit ();
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return AMD_UNIT_TEST_ABORTED;
+  }
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Prerequisite ended.", TestName, IterationName);
+  return AMD_UNIT_TEST_PASSED;
+}
+
+// Test function
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*)UtGetActiveFrameworkHandle();
+  const char* TestName = UtGetTestName(Ut);
+  const char* IterationName = UtGetTestIteration(Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+
+  if (strcmp(IterationName, "TestAXStepping") == 0) {
+    // Arrange
+    PCIe_PLATFORM_CONFIG Pcie = {0};
+    mockComplex.Header.DescriptorFlags = 0;
+    mockSilicon.RBIndex = 0;
+    mockWrapper.WrapId = 0;
+    mockFuseData = SIL_RESERVED2_964; // Set fuse data for harvesting
+    SetIsSteppingAx(true);
+
+    // Act
+    PcieEnumerateAndHarvestWrappers(&Pcie);
+
+    // Assert
+    // If we reach here without crashes, test passed
+    Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+      "Iteration '%s' test passed", IterationName);
+    UtSetTestStatus(Ut, AMD_UNIT_TEST_PASSED);
+  }
+  else if (strcmp(IterationName, "TestBXStepping") == 0) {
+    // Arrange
+    PCIe_PLATFORM_CONFIG Pcie = {0};
+    mockComplex.Header.DescriptorFlags = 0;
+    mockSilicon.RBIndex = 0;
+    mockWrapper.WrapId = 0;
+    mockFuseData = SIL_RESERVED2_956; // Set fuse data for harvesting
+    SetIsSteppingAx(false);
+
+    // Act
+    PcieEnumerateAndHarvestWrappers(&Pcie);
+
+    // Assert
+    // If we reach here without crashes, test passed
+    Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+      "Iteration '%s' test passed", IterationName);
+    UtSetTestStatus(Ut, AMD_UNIT_TEST_PASSED);
+  
+  }else {
+    Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+      "Iteration '%s' test failed", IterationName);
+    UtSetTestStatus (Ut, AMD_UNIT_TEST_ABORTED);
+  }
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+AMD_UNIT_TEST_STATUS
+EFIAPI
+TestCleanUp (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*) UtGetActiveFrameworkHandle ();
+  const char* TestName        = UtGetTestName (Ut);
+  const char* IterationName   = UtGetTestIteration (Ut);
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) CleanUp started.", TestName, IterationName);
+  // Free openSIL allocated memory
+  UtSilDeinit ();
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) CleanUp ended.", TestName, IterationName);
+  return AMD_UNIT_TEST_PASSED;
+}
+
+/**
+ * main
+ * @brief      Stating point for Execution
+ *
+ * @details    This routine:
+ *              - Handles the command line arguments.
+ *              - Declares the unit test framework.
+ *              - Run the tests.
+ *              - Deallocate the Unit test framework.
+ *
+ * @param      argc                     Argument count
+ * @param      *argv[]                  Argument vector
+ *
+ * @retval     AMD_UNIT_TEST_PASSED     Function succeeded
+ * @retval     NON-ZERO                 Error occurs
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_STATUS Status;
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+
+  // Initializing the UnitTest framework
+  Status = UtInitFromArgs (
+    &Ut,
+    argc,
+    argv
+  );
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  char *SimpleCharContext = "A simple TestBody context";
+
+  // Logging the start of the test.
+  // Note: Test status at this time is set to "NOT_SET".
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "Test %s started. TestStatus is %s.", UtGetTestName (&Ut), UtGetTestStatusString (&Ut));
+
+  // You can pass into the TestPrerequisite, TestBody, and TestCleanUp context of
+  // your desire
+  UtSetTestContext (&Ut, (AMD_UNIT_TEST_CONTEXT)SimpleCharContext);
+
+  // Running the test
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest (&Ut);
+
+  // Freeing up all framework related allocated memories
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName (&Ut));
+  UtDeinit (&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/PcieEnumerateAndHarvestWrUt/PcieEnumerateAndHarvestWrUt.h
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/PcieEnumerateAndHarvestWrUt/PcieEnumerateAndHarvestWrUt.h
@@ -1,0 +1,34 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+/**
+ * @file  PcieEnumerateAndHarvestWrUt.h
+ * @brief
+ *
+ */
+
+#pragma once
+
+#include <xSIM.h>
+#include <CommonLib/SmnAccess.h>
+#include <NbioSmnTable.h>
+#include "GnbRegisters.h"
+#include "NbioData.h"
+#include <NBIO/NbioCommon.h>
+#include <NBIO/GnbDxio.h>
+#include <NBIO/NbioPcieTopologyHelper.h>
+#include <NBIO/IOD/include/GlobalRegB0.h>
+#include <NBIO/IOD/include/SyshubmmReg.h>
+#include <NbioPcie.h>
+#include <SilSocLogicalId.h>
+
+#include <UtBaseLib.h>
+#include <UtSilInitLib.h>
+#include <UtLogLib.h>
+#include <NBIO/Nbio.h>
+#include "NbioDefaults.h"
+#include "NbioIohcTbl.h"
+#include "NbioIoapicTbl.h"
+#include "NbioNbifTbl.h"
+#include "NbioWorkaroundTbl.h"
+
+

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/PcieEnumerateAndHarvestWrUt/PcieEnumerateAndHarvestWrUt.inf
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/PcieEnumerateAndHarvestWrUt/PcieEnumerateAndHarvestWrUt.inf
@@ -1,0 +1,38 @@
+# Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# @file  PcieEnumerateAndHarvestWrUt.inf
+# @brief
+#
+
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = PcieEnumerateAndHarvestWrUt
+  FILE_GUID      = 024d5c27-8496-4501-aaff-fa77da685525
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+[BuildOptions]
+# Set the compiler to include the platform openSIL config file
+  MSFT:*_*_*_CC_FLAGS     =  /FI openSIL/configs/Onyx_SilCfg.h
+  GCC:*_*_*_CC_FLAGS      =  -include openSIL/configs/Onyx_SilCfg.h
+
+[Sources]
+  PcieEnumerateAndHarvestWrUt.c
+  PcieEnumerateAndHarvestWrUt.h
+  ../../../../../../../../AmdOpenSilPkg/opensil-uefi-interface/OpenSIL/xUSL/NBIO/IOD/NbioBaseInitGenoa.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  AmdCommonPkg/Test/UnitTest/AgesaModuleUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/UnitTest/AmdOpenSilUtPkg.dec
+  AmdOpenSilPkg/opensil-uefi-interface/AmdOpenSilPkg.dec
+
+[LibraryClasses]
+  UtBaseLib
+  UtIoFakeLib
+  UtSilInitLib
+  UtMmioFakeLib
+  UtSilServicesMockLib

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/PcieEnumerateAndHarvestWrUt/PcieEnumerateAndHarvestWrUt.json
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/PcieEnumerateAndHarvestWrUt/PcieEnumerateAndHarvestWrUt.json
@@ -1,0 +1,8 @@
+[
+  {
+    "Iteration": "TestAXStepping"
+  },
+  {
+    "Iteration": "TestBXStepping"
+  }
+]

--- a/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/PcieEnumerateAndHarvestWrUt/unittest.c
+++ b/AmdOpenSilPkg/opensil-uefi-interface/UnitTest/Source/xUSL/NBIO/IOD/PcieEnumerateAndHarvestWrUt/unittest.c
@@ -1,0 +1,168 @@
+/* Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved. */
+// SPDX-License-Identifier: MIT
+
+#include <UtBaseLib.h>
+#include <UtSilInitLib.h>
+#include <UtLogLib.h>
+#include <NBIO/GnbDxio.h>
+#include <NBIO/NbioPcieTopologyHelper.h>
+#include <NBIO/Nbio.h>
+#include <NBIO/NbioCommon.h>
+#include <UnitTest/AmdUnitTest.h>
+#include <xSIM.h>
+#include <SilSocLogicalId.h>
+
+// Mock data
+static PCIe_COMPLEX_CONFIG mockComplex;
+static PCIe_SILICON_CONFIG mockSilicon;
+static PCIe_WRAPPER_CONFIG mockWrapper;
+static uint32_t mockFuseData;
+static bool isSteppingAx = false;
+
+// Mock functions
+PCIe_DESCRIPTOR_HEADER* 
+PcieConfigGetChild (
+  IN uint32_t Type,
+  IN PCIe_DESCRIPTOR_HEADER* Descriptor
+  )
+{
+  if (Type == DESCRIPTOR_COMPLEX) {
+    return &mockComplex.Header;
+  }
+  if (Type == DESCRIPTOR_SILICON) {
+    return &mockSilicon.Header;
+  }
+  if (Type == DESCRIPTOR_ALL_WRAPPERS) {
+    return &mockWrapper.Header;
+  }
+  return NULL;
+}
+
+PCIe_DESCRIPTOR_HEADER* 
+PcieLibGetNextDescriptor (
+  IN void* Descriptor
+  )
+{
+  // Return NULL to end the loop after first iteration
+  return NULL;
+}
+
+uint32_t 
+xUSLSmnRead (
+  IN uint32_t Segment,
+  IN uint32_t Bus,
+  IN uint32_t Address
+  )
+{
+  return mockFuseData;
+}
+
+bool 
+IsSteppingAx (void)
+{
+  return isSteppingAx;
+}
+
+SIL_STATUS 
+PcieComplexHidePcieCore (
+  IN GNB_HANDLE* GnbHandle,
+  IN uint32_t PcieCoreNum
+  )
+{
+  return SilPass;
+}
+
+// Test function
+void
+EFIAPI
+TestBody (
+  IN AMD_UNIT_TEST_CONTEXT Context
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK *Ut = (AMD_UNIT_TEST_FRAMEWORK*)UtGetActiveFrameworkHandle();
+  const char* TestName = UtGetTestName(Ut);
+  const char* IterationName = UtGetTestIteration(Ut);
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test started.", TestName, IterationName);
+
+  if (strcmp(IterationName, "TestAXStepping") == 0) {
+    // Arrange
+    PCIe_PLATFORM_CONFIG Pcie = {0};
+    mockComplex.Header.DescriptorFlags = 0;
+    mockSilicon.RBIndex = 0;
+    mockWrapper.WrapId = 0;
+    mockFuseData = SIL_RESERVED2_964; // Set fuse data for harvesting
+    isSteppingAx = true;
+
+    // Act
+    PcieEnumerateAndHarvestWrappers(&Pcie);
+
+    // Assert
+    // If we reach here without crashes, test passed
+    UtSetTestStatus(Ut, AMD_UNIT_TEST_PASSED);
+  }
+  else if (strcmp(IterationName, "TestBXStepping") == 0) {
+    // Arrange
+    PCIe_PLATFORM_CONFIG Pcie = {0};
+    mockComplex.Header.DescriptorFlags = 0;
+    mockSilicon.RBIndex = 0;
+    mockWrapper.WrapId = 0;
+    mockFuseData = SIL_RESERVED2_956; // Set fuse data for harvesting
+    isSteppingAx = false;
+
+    // Act
+    PcieEnumerateAndHarvestWrappers(&Pcie);
+
+    // Assert
+    // If we reach here without crashes, test passed
+    UtSetTestStatus(Ut, AMD_UNIT_TEST_PASSED);
+  }
+  else {
+    Ut->Log(AMD_UNIT_TEST_LOG_ERROR, __FUNCTION__, __LINE__,
+      "Unknown test iteration '%s'", IterationName);
+    UtSetTestStatus(Ut, AMD_UNIT_TEST_ABORTED);
+  }
+
+  Ut->Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__,
+    "%s (Iteration: %s) Test ended.", TestName, IterationName);
+}
+
+/**
+ * main
+ *
+ * @brief   Starting point for Execution
+ *
+ * @param   argc  Argument count
+ * @param   argv  Argument vector
+ *
+ * @return  int   0 in success, other in failure
+ */
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  AMD_UNIT_TEST_FRAMEWORK Ut;
+  AMD_UNIT_TEST_STATUS Status;
+
+  // Initialize framework
+  Status = UtInitFromArgs(&Ut, argc, argv);
+  if (Status != AMD_UNIT_TEST_PASSED) {
+    return Status;
+  }
+
+  char *SimpleCharContext = "A simple TestBody context";
+  UtSetTestContext(&Ut, (AMD_UNIT_TEST_CONTEXT)SimpleCharContext);
+
+  // Run test
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Running test.");
+  UtRunTest(&Ut);
+
+  // Cleanup
+  Ut.Log(AMD_UNIT_TEST_LOG_INFO, __FUNCTION__, __LINE__, "Test %s ended.", UtGetTestName(&Ut));
+  UtDeinit(&Ut);
+
+  return AMD_UNIT_TEST_PASSED;
+}


### PR DESCRIPTION
**1. Unit Tests**

a. Added new unit tests for the following functions in CCX/Common/CcxMiscInit.c:

- CcxGetCacWeights() 
- CcxSetCacWeights() 
- CcxEnableSmee() 

b. Added new unit tests for the following functions in DF/Common/BaseFabricTopologyCmn.c:

- DfGetDieInfo() 
- DfGetProcessorInfo()
- DfGetSystemInfo()

**2. Mock Library and Header File**

Added a new mock library UtCpuOpsMockLib and its corresponding include header file UtCpuOpsMockLib in UnitTest/Include/Library to support testing for xUslIsComputeUnitPrimary().

**3. Add a new mock function**

Added a new mock function - MockSilGetCommon2RevXferTableManyTimes() in UtSilServicesMockLib.c & UtSilServicesMockLib.h

Thanks.